### PR TITLE
Adding comments in nearest.f90, changing variable names for clarity

### DIFF
--- a/src/parcels/parcel_nearest.f90
+++ b/src/parcels/parcel_nearest.f90
@@ -104,13 +104,13 @@ module parcel_nearest
                 ! Initialise scaled squared distance between parcels and parcel index:
                 ! In the loop below we want to minimise dsq/vmerge
                 ! By storing dsqmin and vmergemin separately, we can avoid a division
-                ! In the calculation
-                ! We also want to ensure dsq/(a*b) < lambda_max/2
+                ! In the calculation we also want to ensure
+                !   dsq/(a*b) < lambda_max/2
                 ! This will ensure a merged parcel does not split again
                 ! Since vmerge=pi*a*b, this implies
-                ! dsq*pi < 0.5*parcel_info%lambda*vmerge
-                ! This is ensured by initialising the minimisation with
-                ! the values below
+                !   dsq*pi < 0.5*parcel_info%lambda*vmerge
+                ! This is ensured by initialising the minimisation
+                ! with the values below
                 ! Might seem a bit radical to take a large vmergemin and small dsqmin
                 ! but computationally it is easy
                 dsqmin=0.5*parcel_info%lambda


### PR DESCRIPTION
- Comments on nearest.f90
- Changes "dscmin" to "dsqmin", which I think is clearer.