### PR TITLE
Ensure double precision

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_LANG(Fortran)
 # (important for library tests since it autogenerates a file conftest.f90)
 AC_FC_SRCEXT(f90)
 
-FCFLAGS=""
+FCFLAGS="-fdefault-real-8 -fdefault-double-8"
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([


### PR DESCRIPTION
Compiling a simple test program
```
program test

    real :: r = 3.3
    double precision :: d = 3.3

    print *, r
    print *, d

end program test
```
with `gfortran test.90`, yields single precision also for `double precision` variables when not adding a trailing `d0`. This pull request fixes this issue by adding the compiler flags `-fdefault-real-8 -fdefault-double-8`. This results in following output:
```
3.2999999999999998     
3.2999999999999998
```