### PR TITLE
Remove second rank in parcel volume array

### DIFF
--- a/src/parcels/ellipse.f90
+++ b/src/parcels/ellipse.f90
@@ -58,13 +58,13 @@ module ellipse
 
         function get_angles(B, volume, n_parcels) result(angle)
             double precision, intent(in)   :: B(:, :)
-            double precision, intent(in)   :: volume(:, :)
+            double precision, intent(in)   :: volume(:)
             integer,          intent(in)   :: n_parcels
             double precision               :: angle(n_parcels)
             integer                        :: n
 
             do n = 1, n_parcels
-                angle(n) = get_angle(B(n, 1), B(n, 2), volume(n, 1))
+                angle(n) = get_angle(B(n, 1), B(n, 2), volume(n))
             enddo
         end function get_angles
 

--- a/src/parcels/parcel_container.f90
+++ b/src/parcels/parcel_container.f90
@@ -23,10 +23,12 @@ module parcel_container
             velocity,   &
             vorticity,  &
             stretch,    &
-            volume,     &
             buoyancy,   &
             humidity,   &
             B               ! B matrix entries; ordering B(:, 1) = B11, B(:, 2) = B12
+
+        double precision, allocatable, dimension(:) :: &
+            volume
     end type parcel_container_type
 
     type(parcel_container_type) parcels
@@ -70,7 +72,7 @@ module parcel_container
                 call write_h5_dataset_1d(name, "stretch", parcels%stretch(1:n_parcels, 1))
             endif
 
-            call write_h5_dataset_1d(name, "volume", parcels%volume(1:n_parcels, 1))
+            call write_h5_dataset_1d(name, "volume", parcels%volume(1:n_parcels))
 
             call write_h5_dataset_1d(name, "buoyancy", parcels%buoyancy(1:n_parcels, 1))
 
@@ -109,7 +111,7 @@ module parcel_container
                 parcels%stretch(n, 1)  = parcels%stretch(m, 1)
             endif
 
-            parcels%volume(n, 1)  = parcels%volume(m, 1)
+            parcels%volume(n)  = parcels%volume(m)
             parcels%buoyancy(n, 1) = parcels%buoyancy(m, 1)
             parcels%humidity(n, 1) = parcels%humidity(m, 1)
 
@@ -127,7 +129,7 @@ module parcel_container
             allocate(parcels%vorticity(num, 1))
             allocate(parcels%stretch(num, 1))
             allocate(parcels%B(num, 2))
-            allocate(parcels%volume(num, 1))
+            allocate(parcels%volume(num))
             allocate(parcels%buoyancy(num, 1))
             allocate(parcels%humidity(num, 1))
         end subroutine parcel_alloc

--- a/src/parcels/parcel_init.f90
+++ b/src/parcels/parcel_init.f90
@@ -30,15 +30,15 @@ module parcel_init
             endif
 
             ! initialize the volume of each parcel
-            parcels%volume(1:n_parcels, 1) = vcell / dble(parcel_info%n_per_cell)
+            parcels%volume(1:n_parcels) = vcell / dble(parcel_info%n_per_cell)
 
             if (parcel_info%is_elliptic) then
                 deallocate(parcels%stretch)
 
 
                 ! initialze circles
-                parcels%B(1:n_parcels, 1) = get_ab(parcels%volume(1:n_parcels, 1)) ! B11
-                parcels%B(1:n_parcels, 2) = zero                                   ! B12
+                parcels%B(1:n_parcels, 1) = get_ab(parcels%volume(1:n_parcels)) ! B11
+                parcels%B(1:n_parcels, 2) = zero                                ! B12
 
             else
                 deallocate(parcels%B)

--- a/src/parcels/parcel_interpl.f90
+++ b/src/parcels/parcel_interpl.f90
@@ -64,7 +64,7 @@ module parcel_interpl
             double precision  :: pvol, pvor
 
             do n = 1, n_parcels
-                pvol = parcels%volume(n, 1)
+                pvol = parcels%volume(n)
 
                 points = get_ellipse_points(parcels%position(n, :), &
                                             pvol, parcels%B(n, :))
@@ -99,7 +99,7 @@ module parcel_interpl
                 do n = 1, n_parcels
 
                     pos = parcels%position(n, :)
-                    pvol = parcels%volume(n, 1)
+                    pvol = parcels%volume(n)
                     pos(1) = dble(m) * pos(1)
                     V = dble(m) * pvol
                     B = parcels%B(n, :)
@@ -135,7 +135,7 @@ module parcel_interpl
             do n = 1, n_parcels
 
                 pos = parcels%position(n, :)
-                pvol = parcels%volume(n, 1)
+                pvol = parcels%volume(n)
 
                 ! ensure parcel is within the domain
                 call apply_periodic_bc(pos)
@@ -189,7 +189,7 @@ module parcel_interpl
             ncomp = 1
 
             do n = 1, n_parcels
-                pvol = parcels%volume(n, 1)
+                pvol = parcels%volume(n)
 
                 points = get_ellipse_points(parcels%position(n, :), &
                                             pvol, parcels%B(n, :))
@@ -236,7 +236,7 @@ module parcel_interpl
             do n = 1, n_parcels
 
                 pos = parcels%position(n, :)
-                pvol = parcels%volume(n, 1)
+                pvol = parcels%volume(n)
 
                 ! ensure parcel is within the domain
                 call apply_periodic_bc(pos)
@@ -335,7 +335,7 @@ module parcel_interpl
                do n = 1, n_parcels
 
                   points = get_ellipse_points(parcels%position(n, :), &
-                                              parcels%volume(n, 1),   &
+                                              parcels%volume(n),      &
                                               parcels%B(n, :))
 
                   do p = 1, 2
@@ -357,7 +357,7 @@ module parcel_interpl
             do n = 1, n_parcels
 
                 points = get_ellipse_points(parcels%position(n, :), &
-                                            parcels%volume(n, 1),   &
+                                            parcels%volume(n),      &
                                             parcels%B(n, :))
 
                 ! we have 2 points per ellipse

--- a/src/parcels/parcel_merge.f90
+++ b/src/parcels/parcel_merge.f90
@@ -81,11 +81,11 @@ module parcel_merge
             B12_1 = parcels%B(is, 2)
             B12_2 = parcels%B(ib, 2)
 
-            B22_1 = get_B22(B11_1, B12_1, parcels%volume(is, 1))
-            B22_2 = get_B22(B11_2, B12_2, parcels%volume(ib, 1))
+            B22_1 = get_B22(B11_1, B12_1, parcels%volume(is))
+            B22_2 = get_B22(B11_2, B12_2, parcels%volume(ib))
 
-            a1b1 = get_ab(parcels%volume(is, 1))
-            a2b2 = get_ab(parcels%volume(ib, 1))
+            a1b1 = get_ab(parcels%volume(is))
+            a2b2 = get_ab(parcels%volume(ib))
 
             ab = a1b1 + a2b2
             abi = one / ab
@@ -123,7 +123,7 @@ module parcel_merge
                                      + mu2 * parcels%vorticity(ib, 1)
 
             ! update volume
-            parcels%volume(ib, 1) = ab * pi
+            parcels%volume(ib) = ab * pi
         end subroutine do_bimerge
 
 
@@ -207,7 +207,7 @@ module parcel_merge
                     loca(ib) = l
 
                     ! vm will contain the total volume of the merged parcel
-                    vm(l) = parcels%volume(ib, 1)
+                    vm(l) = parcels%volume(ib)
 
                     !x0 stores the x centre of the large parcel
                     x0(l) = parcels%position(ib, 1)
@@ -216,12 +216,12 @@ module parcel_merge
                     xm(l) = zero
 
                     ! zm will contain v(ib)*z(ib)+sum{v(is)*z(is)}
-                    zm(l) = parcels%volume(ib, 1) * parcels%position(ib, 2)
+                    zm(l) = parcels%volume(ib) * parcels%position(ib, 2)
 
                     ! buoyancy and humidity
-                    buoym(l) = parcels%volume(ib, 1) * parcels%buoyancy(ib, 1)
-                    hum(l) = parcels%volume(ib, 1) * parcels%humidity(ib, 1)
-                    vortm(l) = parcels%volume(ib, 1) * parcels%vorticity(ib, 1)
+                    buoym(l) = parcels%volume(ib) * parcels%buoyancy(ib, 1)
+                    hum(l) = parcels%volume(ib) * parcels%humidity(ib, 1)
+                    vortm(l) = parcels%volume(ib) * parcels%vorticity(ib, 1)
 
                     B11m(l) = zero
                     B12m(l) = zero
@@ -232,21 +232,21 @@ module parcel_merge
                 ! "is" refers to the small parcel index
                 is = isma(m) !Small parcel
                 n = loca(ib)  !Index of merged parcel
-                vm(n) = vm(n) + parcels%volume(is, 1) !Accumulate volume of merged parcel
+                vm(n) = vm(n) + parcels%volume(is) !Accumulate volume of merged parcel
 
                 ! works across periodic edge
                 delx = get_delx(parcels%position(is, 1), x0(n))
 
                 ! Accumulate sum of v(is)*(x(is)-x(ib))
-                xm(n) = xm(n) + parcels%volume(is, 1) * delx
+                xm(n) = xm(n) + parcels%volume(is) * delx
 
                 ! Accumulate v(ib)*z(ib)+sum{v(is)*z(is)}
-                zm(n) = zm(n) + parcels%volume(is, 1) * parcels%position(is, 2)
+                zm(n) = zm(n) + parcels%volume(is) * parcels%position(is, 2)
 
                 ! Accumulate buoyancy and humidity
-                buoym(n) = buoym(n) + parcels%volume(is, 1) * parcels%buoyancy(is, 1)
-                hum(n) = hum(n) + parcels%volume(is, 1) * parcels%humidity(is, 1)
-                vortm(n) = vortm(n) + parcels%volume(is, 1) * parcels%vorticity(is, 1)
+                buoym(n) = buoym(n) + parcels%volume(is) * parcels%buoyancy(is, 1)
+                hum(n) = hum(n) + parcels%volume(is) * parcels%humidity(is, 1)
+                vortm(n) = vortm(n) + parcels%volume(is) * parcels%vorticity(is, 1)
             enddo
 
             ! Obtain the merged parcel centres
@@ -279,17 +279,17 @@ module parcel_merge
 
                     vmerge = one / vm(l)
 
-                    B22 = get_B22(parcels%B(ib, 1), parcels%B(ib, 2), parcels%volume(ib, 1))
+                    B22 = get_B22(parcels%B(ib, 1), parcels%B(ib, 2), parcels%volume(ib))
 
                     delx = get_delx(parcels%position(ib, 1), xm(l))
                     dely = parcels%position(ib, 2) - zm(l)
 
-                    mu = parcels%volume(ib, 1) * vmerge
+                    mu = parcels%volume(ib) * vmerge
                     B11m(l) = mu * (four * delx ** 2 + parcels%B(ib, 1))
                     B12m(l) = mu * (four * delx * dely + parcels%B(ib, 2))
                     B22m(l) = mu * (four * dely ** 2 + B22)
 
-                    parcels%volume(ib, 1)  = vm(l)
+                    parcels%volume(ib)  = vm(l)
                     parcels%position(ib, 1) = xm(l)
                     parcels%position(ib, 2) = zm(l)
 
@@ -307,10 +307,10 @@ module parcel_merge
                 delx = get_delx(parcels%position(is, 1), xm(n))
                 dely = parcels%position(is, 2) - zm(n)
 
-                B22 = get_B22(parcels%B(is, 1), parcels%B(is, 2), parcels%volume(is, 1))
+                B22 = get_B22(parcels%B(is, 1), parcels%B(is, 2), parcels%volume(is))
 
                 ! volume fraction A_{is} / A
-                mu = vmerge * parcels%volume(is, 1)
+                mu = vmerge * parcels%volume(is)
 
                 B11m(n) = B11m(n) + mu * (four * delx ** 2   + parcels%B(is, 1))
                 B12m(n) = B12m(n) + mu * (four * delx * dely + parcels%B(is, 2))

--- a/src/parcels/parcel_nearest.f90
+++ b/src/parcels/parcel_nearest.f90
@@ -41,7 +41,7 @@ module parcel_nearest
             vmin = vcell / dble(parcel_info%vfraction)
 
             ! These parcels are marked for merger:
-            l_merge(1:n_parcels)=(parcels%volume(1:n_parcels, 1) < vmin)
+            l_merge(1:n_parcels)=(parcels%volume(1:n_parcels) < vmin)
             nmerge=0
 
             !---------------------------------------------------------------------
@@ -127,7 +127,7 @@ module parcel_nearest
                             i=node(k)
                             delz=parcels%position(i,2)-z_small
                             ! Avoid merger with another small parcel
-                            vmerge=parcels%volume(i, 1)+parcels%volume(i0, 1) ! Summed area fraction:
+                            vmerge=parcels%volume(i)+parcels%volume(i0) ! Summed area fraction:
                             ! Minimise dsq/vmerge
                             ! Prevent division in comparisons here by storing both
                             ! vmergemin and dsqmin

--- a/src/parcels/parcel_split.f90
+++ b/src/parcels/parcel_split.f90
@@ -25,14 +25,14 @@ module parcel_split
             double precision                           :: evec(2)
             double precision                           :: h
             integer                                    :: last_index
-            integer                                    :: i
+            integer                                    :: n
 
             last_index = n_parcels
 
-            do i = 1, last_index
-                B11 = parcels%B(i, 1)
-                B12 = parcels%B(i, 2)
-                V = parcels%volume(i, 1)
+            do n = 1, last_index
+                B11 = parcels%B(n, 1)
+                B12 = parcels%B(n, 2)
+                V = parcels%volume(n)
                 B22 = get_B22(B11, B12, V)
 
                 a2 = get_eigenvalue(B11, B12, B22)
@@ -50,25 +50,25 @@ module parcel_split
 
                 evec = get_eigenvector(a2, B12, B22)
 
-                parcels%B(i, 1) = B11 - 0.75d0 * a2 * evec(1) ** 2
-                parcels%B(i, 2) = B12 - 0.75d0 * a2 * (evec(1) * evec(2))
+                parcels%B(n, 1) = B11 - 0.75d0 * a2 * evec(1) ** 2
+                parcels%B(n, 2) = B12 - 0.75d0 * a2 * (evec(1) * evec(2))
 
                 h = 0.25d0 * dsqrt(three * a2)
-                parcels%volume(i, 1) = 0.5d0 * V
+                parcels%volume(n) = 0.5d0 * V
 
                 ! we only need to add one new parcel
                 n_parcels = n_parcels + 1
 
-                parcels%B(n_parcels, :) = parcels%B(i, :)
+                parcels%B(n_parcels, :) = parcels%B(n, :)
 
-                parcels%velocity(n_parcels, :) = parcels%velocity(i, :)
-                parcels%vorticity(n_parcels, :) = parcels%vorticity(i, :)
-                parcels%volume(n_parcels, 1) = parcels%volume(i, 1)
-                parcels%buoyancy(n_parcels, 1) = parcels%buoyancy(i, 1)
-                parcels%humidity(n_parcels, 1) = parcels%humidity(i, 1)
+                parcels%velocity(n_parcels, :) = parcels%velocity(n, :)
+                parcels%vorticity(n_parcels, :) = parcels%vorticity(n, :)
+                parcels%volume(n_parcels) = parcels%volume(n)
+                parcels%buoyancy(n_parcels, 1) = parcels%buoyancy(n, 1)
+                parcels%humidity(n_parcels, 1) = parcels%humidity(n, 1)
 
-                parcels%position(n_parcels, :) = parcels%position(i, :) - h * evec
-                parcels%position(i, :) = parcels%position(i, :)  + h * evec
+                parcels%position(n_parcels, :) = parcels%position(n, :) - h * evec
+                parcels%position(n, :) = parcels%position(n, :)  + h * evec
             enddo
 
             if (verbose) then

--- a/src/stepper/classic_rk4.f90
+++ b/src/stepper/classic_rk4.f90
@@ -112,7 +112,7 @@ module classic_rk4
             call vor2vel(vortg, velog, velgradg)
             call grid2par(k1o, w1o, strain)
             b1o(1:n_parcels,:) = get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                       parcels%volume(1:n_parcels, 1))
+                                       parcels%volume(1:n_parcels))
 
             ! apply velocity BC --> only important for free slip
             call apply_parcel_bc(parcels%position, k1o)
@@ -129,7 +129,7 @@ module classic_rk4
             call vor2vel(vortg, velog, velgradg)
             call grid2par(k2o, w2o, strain)
             b2o(1:n_parcels,:) = get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                       parcels%volume(1:n_parcels, 1))
+                                       parcels%volume(1:n_parcels))
 
             ! apply velocity BC --> only important for free slip
             call apply_parcel_bc(parcels%position, k2o)
@@ -146,7 +146,7 @@ module classic_rk4
             call vor2vel(vortg, velog, velgradg)
             call grid2par(k3o, w3o, strain)
             b3o(1:n_parcels,:) = get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                       parcels%volume(1:n_parcels, 1))
+                                       parcels%volume(1:n_parcels))
 
 
             ! apply velocity BC --> only important for free slip
@@ -163,7 +163,7 @@ module classic_rk4
             call vor2vel(vortg, velog, velgradg)
             call grid2par(k4o, w4o, strain)
             b4o(1:n_parcels,:) = get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                       parcels%volume(1:n_parcels, 1))
+                                       parcels%volume(1:n_parcels))
 
             ! apply velocity BC --> only important for free slip
             call apply_parcel_bc(parcels%position, k4o)

--- a/src/stepper/ls_rk4.f90
+++ b/src/stepper/ls_rk4.f90
@@ -92,11 +92,11 @@ module ls_rk4
             endif
             if(step==1) then
                dbdt(1:n_parcels,:) = get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                           parcels%volume(1:n_parcels, 1))
+                                           parcels%volume(1:n_parcels))
             else
                dbdt(1:n_parcels,:) = dbdt(1:n_parcels,:) &
                                    + get_B(parcels%B(1:n_parcels,:), strain(1:n_parcels,:), &
-                                           parcels%volume(1:n_parcels, 1))
+                                           parcels%volume(1:n_parcels))
             endif
             parcels%position(1:n_parcels,:) = parcels%position(1:n_parcels,:) + cb*dt*velocity_p(1:n_parcels,:)
             parcels%vorticity(1:n_parcels, :) = parcels%vorticity(1:n_parcels, :) + cb*dt*dwdt(1:n_parcels, :)

--- a/unit-tests/test_diverge.f90
+++ b/unit-tests/test_diverge.f90
@@ -56,7 +56,7 @@ program test_diverge
     parcels%volume = 0.25d0 * vcell
 
     ! b11
-    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels, 1))
+    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels))
 
     ! b12
     parcels%B(:, 2) = zero

--- a/unit-tests/test_diverge_gradient.f90
+++ b/unit-tests/test_diverge_gradient.f90
@@ -57,7 +57,7 @@ program test_diverge_gradient
     parcels%volume = 0.25d0 * vcell
 
     ! b11
-    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels, 1))
+    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels))
 
     ! b12
     parcels%B(:, 2) = zero

--- a/unit-tests/test_ellipse_bi_merge.f90
+++ b/unit-tests/test_ellipse_bi_merge.f90
@@ -29,7 +29,7 @@ program test_ellipse_bi_merge
     ! parcels
     a1b1 = two
     parcels%position(1, :) = zero
-    parcels%volume(1, 1) = a1b1 * pi
+    parcels%volume(1) = a1b1 * pi
     parcels%B(1, 1) = a1b1
     parcels%B(1, 2) = zero
     parcels%buoyancy(1, 1) = 1.5d0
@@ -37,7 +37,7 @@ program test_ellipse_bi_merge
 
     a2b2 = 0.5d0
     parcels%position(2, :) = zero
-    parcels%volume(2, 1) = a2b2 * pi
+    parcels%volume(2) = a2b2 * pi
     parcels%B(2, 1) = a2b2
     parcels%B(2, 2) = zero
     parcels%buoyancy(2, 1) = 1.8d0
@@ -69,9 +69,9 @@ program test_ellipse_bi_merge
     error = max(error, abs(parcels%B(1, 2) - B12))
     error = max(error, abs(get_B22(parcels%B(1, 1), &
                                    parcels%B(1, 2), &
-                                   parcels%volume(1, 1)) - B22))
+                                   parcels%volume(1)) - B22))
     error = max(error, sum(abs(parcels%position(1, :))))
-    error = max(error, abs(parcels%volume(1, 1) - vol))
+    error = max(error, abs(parcels%volume(1) - vol))
     error = max(error, abs(parcels%buoyancy(1, 1) - buoy))
     error = max(error, abs(parcels%humidity(1, 1) - hum))
 
@@ -81,7 +81,7 @@ program test_ellipse_bi_merge
     n_parcels = 2
     a1b1 = two
     parcels%position(1, :) = zero
-    parcels%volume(1, 1) = a1b1 * pi
+    parcels%volume(1) = a1b1 * pi
     parcels%B(1, 1) = a1b1
     parcels%B(1, 2) = zero
     parcels%buoyancy(1, 1) = 1.5d0
@@ -89,7 +89,7 @@ program test_ellipse_bi_merge
 
     a2b2 = 0.5d0
     parcels%position(2, :) = zero
-    parcels%volume(2, 1) = a2b2 * pi
+    parcels%volume(2) = a2b2 * pi
     parcels%B(2, 1) = a2b2
     parcels%B(2, 2) = zero
     parcels%buoyancy(2, 1) = 1.8d0
@@ -110,9 +110,9 @@ program test_ellipse_bi_merge
     error = max(error, abs(parcels%B(1, 2) - B12))
     error = max(error, abs(get_B22(parcels%B(1, 1), &
                                    parcels%B(1, 2), &
-                                   parcels%volume(1, 1)) - B22))
+                                   parcels%volume(1)) - B22))
     error = max(error, sum(abs(parcels%position(1, :))))
-    error = max(error, abs(parcels%volume(1, 1) - vol))
+    error = max(error, abs(parcels%volume(1) - vol))
     error = max(error, abs(parcels%buoyancy(1, 1) - buoy))
     error = max(error, abs(parcels%humidity(1, 1) - hum))
 

--- a/unit-tests/test_ellipse_bi_vs_multi_merge.f90
+++ b/unit-tests/test_ellipse_bi_vs_multi_merge.f90
@@ -39,7 +39,7 @@ program test_ellipse_bi_vs_multi_merge
     B11 = parcels%B(1, 1)
     B12 = parcels%B(1, 2)
     pos = parcels%position(1, :)
-    vol = parcels%volume(1, 1)
+    vol = parcels%volume(1)
 
     call parcel_setup
     parcel_info%merge_type = 'bi-geometric'
@@ -50,7 +50,7 @@ program test_ellipse_bi_vs_multi_merge
     error = max(error, abs(parcels%B(1, 1) - B11))
     error = max(error, abs(parcels%B(1, 2) - B12))
     error = max(error, sum(abs(parcels%position(1, :) - pos)))
-    error = max(error, abs(parcels%volume(1, 1) - vol))
+    error = max(error, abs(parcels%volume(1) - vol))
 
     call print_result_dp('Test ellipse bi-merge vs multi-merge (geometric)', error)
 
@@ -70,7 +70,7 @@ program test_ellipse_bi_vs_multi_merge
     B11 = parcels%B(1, 1)
     B12 = parcels%B(1, 2)
     pos = parcels%position(1, :)
-    vol = parcels%volume(1, 1)
+    vol = parcels%volume(1)
 
     call parcel_setup
     parcel_info%merge_type = 'bi-optimal'
@@ -81,7 +81,7 @@ program test_ellipse_bi_vs_multi_merge
     error = max(error, abs(parcels%B(1, 1) - B11))
     error = max(error, abs(parcels%B(1, 2) - B12))
     error = max(error, sum(abs(parcels%position(1, :) - pos)))
-    error = max(error, abs(parcels%volume(1, 1) - vol))
+    error = max(error, abs(parcels%volume(1) - vol))
 
     call print_result_dp('Test ellipse bi-merge vs multi-merge (optimal)', error)
 
@@ -100,14 +100,14 @@ program test_ellipse_bi_vs_multi_merge
             n_parcels = 2
             parcels%position(1, 1) = 1.5d0
             parcels%position(1, 2) = 0.2d0
-            parcels%volume(1, 1) = a1b1 * pi
+            parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(1, 2) = zero
 
             ! small parcel left
             parcels%position(2, 1) = 1.5d0 - d
             parcels%position(2, 2) = 0.2d0 - d
-            parcels%volume(2, 1) = a2b2 * pi
+            parcels%volume(2) = a2b2 * pi
             parcels%B(2, 1) = a2b2
             parcels%B(2, 2) = zero
 

--- a/unit-tests/test_ellipse_multi_merge_1.f90
+++ b/unit-tests/test_ellipse_multi_merge_1.f90
@@ -72,7 +72,7 @@ program test_ellipse_multi_merge_1
         subroutine parcel_setup
             n_parcels = 5
             parcels%position(1, :) = zero
-            parcels%volume(1, 1) = a1b1 * pi
+            parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(1, 2) = zero
             parcels%buoyancy(1, 1) = 1.5d0
@@ -81,7 +81,7 @@ program test_ellipse_multi_merge_1
             ! small parcel left
             parcels%position(2, 1) = -1.2d0
             parcels%position(2, 2) = zero
-            parcels%volume(2, 1) = a2b2 * pi
+            parcels%volume(2) = a2b2 * pi
             parcels%B(2, 1) = a2b2
             parcels%B(2, 2) = zero
             parcels%buoyancy(2, 1) = 1.8d0
@@ -90,7 +90,7 @@ program test_ellipse_multi_merge_1
             ! small parcel right
             parcels%position(3, 1) = 1.2d0
             parcels%position(3, 2) = zero
-            parcels%volume(3, 1) = a2b2 * pi
+            parcels%volume(3) = a2b2 * pi
             parcels%B(3, 1) = a2b2
             parcels%B(3, 2) = zero
             parcels%buoyancy(3, 1) = 1.4d0
@@ -99,7 +99,7 @@ program test_ellipse_multi_merge_1
             ! small parcel below
             parcels%position(4, 1) = zero
             parcels%position(4, 2) = -1.2d0
-            parcels%volume(4, 1) = a2b2 * pi
+            parcels%volume(4) = a2b2 * pi
             parcels%B(4, 1) = a2b2
             parcels%B(4, 2) = zero
             parcels%buoyancy(4, 1) = 1.7d0
@@ -108,7 +108,7 @@ program test_ellipse_multi_merge_1
             ! small parcel above
             parcels%position(5, 1) = zero
             parcels%position(5, 2) = 1.2d0
-            parcels%volume(5, 1) = a2b2 * pi
+            parcels%volume(5) = a2b2 * pi
             parcels%B(5, 1) = a2b2
             parcels%B(5, 2) = zero
             parcels%buoyancy(5, 1) = 1.5d0
@@ -136,9 +136,9 @@ program test_ellipse_multi_merge_1
             max_err = max(max_err, abs(parcels%B(1, 2) - B12))
             max_err = max(max_err, abs(get_B22(parcels%B(1, 1), &
                                                parcels%B(1, 2), &
-                                               parcels%volume(1, 1)) - B22))
+                                               parcels%volume(1)) - B22))
             max_err = max(max_err, sum(abs(parcels%position(1, :))))
-            max_err = max(max_err, abs(parcels%volume(1, 1) - vol))
+            max_err = max(max_err, abs(parcels%volume(1) - vol))
             max_err = max(max_err, abs(parcels%buoyancy(1, 1) - buoy))
             max_err = max(max_err, abs(parcels%humidity(1, 1) - hum))
         end function eval_max_error

--- a/unit-tests/test_ellipse_multi_merge_2.f90
+++ b/unit-tests/test_ellipse_multi_merge_2.f90
@@ -76,7 +76,7 @@ program test_ellipse_multi_merge_2
 
             n_parcels = 3
             parcels%position(1, :) = zero
-            parcels%volume(1, 1) = a1b1 * pi
+            parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(1, 2) = zero
             parcels%buoyancy(1, 1) = 1.5d0
@@ -85,7 +85,7 @@ program test_ellipse_multi_merge_2
             ! small parcel left
             parcels%position(2, 1) = -d
             parcels%position(2, 2) = -d
-            parcels%volume(2, 1) = a2b2 * pi
+            parcels%volume(2) = a2b2 * pi
             parcels%B(2, 1) = a2b2
             parcels%B(2, 2) = zero
             parcels%buoyancy(2, 1) = 1.8d0
@@ -94,7 +94,7 @@ program test_ellipse_multi_merge_2
             ! small parcel right
             parcels%position(3, 1) = d
             parcels%position(3, 2) = d
-            parcels%volume(3, 1) = a2b2 * pi
+            parcels%volume(3) = a2b2 * pi
             parcels%B(3, 1) = a2b2
             parcels%B(3, 2) = zero
             parcels%buoyancy(3, 1) = 1.4d0
@@ -138,9 +138,9 @@ program test_ellipse_multi_merge_2
             max_err = max(max_err, abs(parcels%B(1, 2) - B12))
             max_err = max(max_err, abs(get_B22(parcels%B(1, 1), &
                                                parcels%B(1, 2), &
-                                               parcels%volume(1, 1)) - B22))
+                                               parcels%volume(1)) - B22))
             max_err = max(max_err, sum(abs(parcels%position(1, :))))
-            max_err = max(max_err, abs(parcels%volume(1, 1) - vol))
+            max_err = max(max_err, abs(parcels%volume(1) - vol))
             max_err = max(max_err, abs(parcels%buoyancy(1, 1) - buoy))
             max_err = max(max_err, abs(parcels%humidity(1, 1) - hum))
         end function eval_max_error

--- a/unit-tests/test_ellipse_multi_merge_3.f90
+++ b/unit-tests/test_ellipse_multi_merge_3.f90
@@ -75,21 +75,21 @@ program test_ellipse_multi_merge_3
             n_parcels = 3
             parcels%position(1, 1) = 1.5d0
             parcels%position(1, 2) = 0.2d0
-            parcels%volume(1, 1) = a1b1 * pi
+            parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = a1b1
             parcels%B(1, 2) = zero
 
             ! small parcel left
             parcels%position(2, 1) = 1.5d0 - d
             parcels%position(2, 2) = 0.2d0 -d
-            parcels%volume(2, 1) = a2b2 * pi
+            parcels%volume(2) = a2b2 * pi
             parcels%B(2, 1) = a2b2
             parcels%B(2, 2) = zero
 
             ! small parcel right
             parcels%position(3, 1) = -extent(1) + 1.5d0 + d
             parcels%position(3, 2) = 0.2d0 + d
-            parcels%volume(3, 1) = a2b2 * pi
+            parcels%volume(3) = a2b2 * pi
             parcels%B(3, 1) = a2b2
             parcels%B(3, 2) = zero
 
@@ -128,9 +128,9 @@ program test_ellipse_multi_merge_3
             max_err = max(max_err, abs(parcels%B(1, 2) - B12))
             max_err = max(max_err, abs(get_B22(parcels%B(1, 1), &
                                                parcels%B(1, 2), &
-                                               parcels%volume(1, 1)) - B22))
+                                               parcels%volume(1)) - B22))
             max_err = max(max_err, sum(abs(parcels%position(1, :) - (/1.5d0, 0.2d0/))))
-            max_err = max(max_err, abs(parcels%volume(1, 1) - vol))
+            max_err = max(max_err, abs(parcels%volume(1) - vol))
         end function eval_max_error
 
 

--- a/unit-tests/test_ellipse_multi_merge_symmetry.f90
+++ b/unit-tests/test_ellipse_multi_merge_symmetry.f90
@@ -79,19 +79,19 @@ program test_ellipse_multi_merge_symmetry
             n_parcels = 6
             parcels%position(1, 1) = -0.5d0
             parcels%position(1, 2) = 0.2d0
-            parcels%volume(1, 1) = a1b1 * pi
+            parcels%volume(1) = a1b1 * pi
             parcels%B(1, 1) = 1.2d0 * a1b1
             parcels%B(1, 2) = -0.4d0
 
             parcels%position(2, 1) = -0.6d0
             parcels%position(2, 2) = 0.3d0
-            parcels%volume(2, 1) = a2b2 * pi
+            parcels%volume(2) = a2b2 * pi
             parcels%B(2, 1) = 0.8d0 * a2b2
             parcels%B(2, 2) = 0.5d0
 
             parcels%position(3, 1) = -0.3d0
             parcels%position(3, 2) = -0.1d0
-            parcels%volume(3, 1) = a2b2 * pi
+            parcels%volume(3) = a2b2 * pi
             parcels%B(3, 1) = 0.9d0 * a2b2
             parcels%B(3, 2) = -0.1d0
 
@@ -101,7 +101,7 @@ program test_ellipse_multi_merge_symmetry
             do n = 1, 3
                 parcels%position(3+n, 1) = -parcels%position(n, 1)
                 parcels%position(3+n, 2) =  parcels%position(n, 2)
-                parcels%volume(3+n, 1) = parcels%volume(n, 1)
+                parcels%volume(3+n) = parcels%volume(n)
                 parcels%B(3+n, 1) =  parcels%B(n, 1)
                 parcels%B(3+n, 2) = -parcels%B(n, 2)
             enddo

--- a/unit-tests/test_ellipse_orientation.f90
+++ b/unit-tests/test_ellipse_orientation.f90
@@ -26,7 +26,7 @@ program test_ellipse_orientation
     parcels%position = zero
     parcels%volume = 0.25d0 * product(extent / (grid - 1))
 
-    V = parcels%volume(1, 1)
+    V = parcels%volume(1)
 
     a2 = (lam * V) / pi
     b2 = V / (pi * lam)

--- a/unit-tests/test_ellipse_split.f90
+++ b/unit-tests/test_ellipse_split.f90
@@ -25,7 +25,7 @@ program test_ellipse_split
     b2 = ab / lam
 
     parcels%position(1, :) = zero
-    parcels%volume(1, 1) = ab * pi
+    parcels%volume(1) = ab * pi
     parcels%buoyancy(1, 1) = one
     parcels%humidity(1, 1) = one
 
@@ -56,7 +56,7 @@ program test_ellipse_split
     error = max(error, abs(parcels%B(1, 1) - B11))
     error = max(error, abs(parcels%B(1, 2) - B12))
     error = max(error, sum(abs(pos(1, :) - parcels%position(1, :))))
-    error = max(error, sum(abs(0.5d0 * ab * pi - parcels%volume(1, :))))
+    error = max(error, abs(0.5d0 * ab * pi - parcels%volume(1)))
     error = max(error, abs(parcels%buoyancy(1, 1) - one))
     error = max(error, abs(parcels%humidity(1, 1) - one))
 
@@ -65,7 +65,7 @@ program test_ellipse_split
     error = max(error, abs(parcels%B(2, 1) - B11))
     error = max(error, abs(parcels%B(2, 2) - B12))
     error = max(error, sum(abs(pos(2, :) - parcels%position(2, :))))
-    error = max(error, sum(abs(0.5d0 * ab * pi - parcels%volume(2, :))))
+    error = max(error, abs(0.5d0 * ab * pi - parcels%volume(2)))
     error = max(error, dble(abs(n_parcels - 2)))
     error = max(error, abs(parcels%buoyancy(2, 1) - one))
     error = max(error, abs(parcels%humidity(2, 1) - one))

--- a/unit-tests/test_trilinear.f90
+++ b/unit-tests/test_trilinear.f90
@@ -48,7 +48,7 @@ program test_trilinear
     parcels%volume = 0.25d0 * vcell
 
     ! b11
-    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels, 1))
+    parcels%B(:, 1) = get_ab(parcels%volume(1:n_parcels))
 
     ! b12
     parcels%B(:, 2) = zero


### PR DESCRIPTION
With pull request #107 we changed `par2grid` and `grid2par`. Hence, we do not need the second rank in the parcel volume array anymore.