### PR TITLE
Remove Fortran mod files in make clean

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,3 +26,6 @@ epic_SOURCES = 					\
 	stepper/ls_rk4.f90			\
 	stepper/rk4.f90 			\
 	epic.f90
+
+clean-local:
+	rm -f *.mod


### PR DESCRIPTION
When we compile EPIC, we get `*.mod` files that are not removed when we do `make clean`. They should, however, be deleted. This pull request fixes this.