### PR TITLE
Fix failing unit tests

### DIFF
--- a/unit-tests/test_parcel_init.f90
+++ b/unit-tests/test_parcel_init.f90
@@ -11,7 +11,7 @@ program test_parcel_init
     use parcel_interpl, only : par2grid
     use parcel_ellipse, only : get_ab
     use fields, only : tbuoyg, field_default
-    use parameters, only : update_parameters, dx, ncell, nx, nz, lower
+    use parameters, only : update_parameters, dx, ncell, nx, nz, lower, vcell
     implicit none
 
     double precision  :: xg, zg, facx, facz, argx, argz, v0
@@ -60,7 +60,7 @@ program test_parcel_init
 
     !---------------------------------------------------------
     !Initialise parcel volume positions and volume fractions:
-    v0 = dxf * dzf !use equal volume fraction for each parcel
+    v0 = dxf * dzf * vcell
     i = 0
     do iz = 0, nz-1
         do ix = 0, nx-1

--- a/unit-tests/test_tri_inversion.f90
+++ b/unit-tests/test_tri_inversion.f90
@@ -18,7 +18,7 @@ program test_tri_inversion
 
     nx = 40
     nz = 20
-    lower  = (/-1.5, -1.5/)
+    lower  = (/-two, -one/)
     extent = (/four, two/)
 
     call update_parameters


### PR DESCRIPTION
The unit test `test_parcel_init.f90` fails since it still uses volume fractions rather than the "true" volume. This is fixed by multiplying the parcel volumes with `vcell`. The unit test `test_tri_inversion.f90` fails since the domain is not the same like in the reference program.