### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,8 @@ AM_CONDITIONAL([ENABLE_DEBUG], [test "$ENABLE_DEBUG" = "yes"])
 AC_MSG_CHECKING([whether we are compiling in debug mode])
 if test "x$ENABLE_DEBUG" = "xyes"; then
     AC_MSG_RESULT([yes])
-    FCFLAGS="$FCFLAGS -g -O0 -fbounds-check -fbacktrace -ffpe-trap=zero,overflow,underflow"
+    FCFLAGS="$FCFLAGS -Wall -Wno-maybe-uninitialized -Werror -g -O0"
+    FCFLAGS="$FCFLAGS -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow,underflow"
 else
     AC_MSG_RESULT([no])
     FCFLAGS="$FCFLAGS -O3 -DNDEBUG"

--- a/src/epic.f90
+++ b/src/epic.f90
@@ -95,7 +95,10 @@ program epic
 
 
         subroutine run
-            use options, only : time, output, verbose, parcel
+            use options, only : time, output, parcel
+#ifdef ENABLE_VERBOSE
+            use options, only : verbose
+#endif
             double precision :: t    = zero ! current time
             double precision :: dt   = zero ! time step
             integer          :: iter = 1    ! simulation iteration
@@ -233,7 +236,10 @@ program epic
 
     ! Get the file name provided via the command line
     subroutine parse_command_line
-        use options, only : filename, verbose
+        use options, only : filename
+#ifdef ENABLE_VERBOSE
+        use options, only : verbose
+#endif
         integer                          :: i
         character(len=512)               :: arg
 

--- a/src/fields/field_hdf5.f90
+++ b/src/fields/field_hdf5.f90
@@ -46,7 +46,6 @@ module field_hdf5
         end subroutine create_h5_field_file
 
         subroutine write_h5_field_step(nw, t, dt)
-            use options, only : output
             integer,          intent(inout) :: nw
             double precision, intent(in)    :: t
             double precision, intent(in)    :: dt

--- a/src/hdf5/h5_writer.f90
+++ b/src/hdf5/h5_writer.f90
@@ -176,8 +176,6 @@ module h5_writer
             double precision, intent(in)     :: val
             integer(hid_t)                   :: group
             character(:), allocatable        :: grn
-            integer(hid_t)                   :: attr, space
-            integer(hsize_t), dimension(1:1) :: dims = 1
             logical                          :: created
 
             grn = trim(get_step_group_name(iter))
@@ -201,8 +199,6 @@ module h5_writer
             integer,          intent(in)     :: val
             integer(hid_t)                   :: group
             character(:), allocatable        :: grn
-            integer(hid_t)                   :: attr, space
-            integer(hsize_t), dimension(1:1) :: dims = 1
             logical                          :: created
 
             grn = trim(get_step_group_name(iter))

--- a/src/parcels/parcel_diagnostics.f90
+++ b/src/parcels/parcel_diagnostics.f90
@@ -48,7 +48,7 @@ module parcel_diagnostics
 
         subroutine calculate_diagnostics
             integer          :: n
-            double precision :: b, z, v, vel(2), vol, zmin
+            double precision :: b, z, vel(2), vol, zmin
 
             ! reset
             ke = zero

--- a/src/parcels/parcel_init.f90
+++ b/src/parcels/parcel_init.f90
@@ -104,7 +104,7 @@ module parcel_init
             double precision :: del(2)
 
             ! number of parcels per dimension
-            n_per_dim = dsqrt(dble(parcel%n_per_cell))
+            n_per_dim = int(dsqrt(dble(parcel%n_per_cell)))
             if (n_per_dim ** 2 .ne. parcel%n_per_cell) then
                 print *, "Number of parcels per cell (", &
                          parcel%n_per_cell, ") not a square."

--- a/src/parcels/parcel_interpl.f90
+++ b/src/parcels/parcel_interpl.f90
@@ -66,7 +66,7 @@ module parcel_interpl
         subroutine vol2grid_elliptic
             double precision  :: points(2, 2)
             integer           :: n, p, l
-            double precision  :: pvol, pvor
+            double precision  :: pvol
 
             do n = 1, n_parcels
                 pvol = parcels%volume(n)
@@ -255,7 +255,7 @@ module parcel_interpl
         subroutine par2grid_elliptic
             double precision  :: points(2, 2)
             integer           :: n, p, l, i, j
-            double precision  :: pvol, pvor, weight, btot, h_c
+            double precision  :: pvol, weight, btot, h_c
 
             do n = 1, n_parcels
                 pvol = parcels%volume(n)

--- a/src/parcels/parcel_merge.f90
+++ b/src/parcels/parcel_merge.f90
@@ -336,7 +336,7 @@ module parcel_merge
             integer,                     intent(in)    :: n_merge
             integer                                    :: m, ib, l
             integer                                    :: loca(n_parcels)
-            double precision                           :: factor, mu
+            double precision                           :: factor
             double precision                           :: B11(n_merge), &
                                                           B12(n_merge), &
                                                           B22(n_merge), &

--- a/unit-tests/test_ellipse_multi_merge_2.f90
+++ b/unit-tests/test_ellipse_multi_merge_2.f90
@@ -109,7 +109,7 @@ program test_ellipse_multi_merge_2
 
         function eval_max_error(method) result(max_err)
             character(*), intent(in) :: method
-            double precision :: ab, B11, B12, B22, vol, angle, d, factor, tmp, mu
+            double precision :: ab, B11, B12, B22, vol, d, factor, tmp, mu
             double precision :: max_err, hum, buoy
 
             ! reference solution

--- a/unit-tests/test_ellipse_multi_merge_3.f90
+++ b/unit-tests/test_ellipse_multi_merge_3.f90
@@ -102,7 +102,7 @@ program test_ellipse_multi_merge_3
 
         function eval_max_error(method) result(max_err)
             character(*), intent(in) :: method
-            double precision :: ab, B11, B12, B22, vol, angle, d, factor, tmp, mu
+            double precision :: ab, B11, B12, B22, vol, d, factor, tmp, mu
             double precision :: max_err
 
             ! reference solution

--- a/unit-tests/test_ellipse_multi_merge_symmetry.f90
+++ b/unit-tests/test_ellipse_multi_merge_symmetry.f90
@@ -75,7 +75,7 @@ program test_ellipse_multi_merge_symmetry
     contains
 
         subroutine parcel_setup
-            double precision :: d, a1b1, a2b2
+            double precision :: a1b1, a2b2
             integer :: n
 
             a1b1 = 1.44d0

--- a/unit-tests/test_ellipse_orientation.f90
+++ b/unit-tests/test_ellipse_orientation.f90
@@ -12,7 +12,6 @@ program test_ellipse_orientation
     use parcel_ellipse
     implicit none
 
-    double precision :: origin(2) = (/zero, zero/)
     double precision :: extent(2) =  (/0.2d0, 0.2d0/)
     integer :: iter
     integer :: grid(2) = (/2, 2/)

--- a/unit-tests/test_ellipse_reflection.f90
+++ b/unit-tests/test_ellipse_reflection.f90
@@ -15,7 +15,7 @@ program test_ellipse_reflection
     implicit none
 
     integer :: iter
-    double precision :: angle, ab, B11, B12, B22, error, a2, b2
+    double precision :: angle, ab, B11, B12, error, a2, b2
 
     nx = 10
     nz = 10

--- a/unit-tests/test_gradient_correction.f90
+++ b/unit-tests/test_gradient_correction.f90
@@ -13,7 +13,7 @@ program test_parcel_correction
     use parcel_interpl, only : vol2grid, vol2grid_timer
     use parcel_ellipse, only : get_ab
     use options, only : parcel
-    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz, ngrid
+    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz
     use fields, only : volg
     use timer
 

--- a/unit-tests/test_laplace_correction.f90
+++ b/unit-tests/test_laplace_correction.f90
@@ -13,7 +13,7 @@ program test_laplace_correction
     use parcel_interpl, only : vol2grid, vol2grid_timer
     use options, only : parcel
     use parcel_ellipse, only : get_ab
-    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz, ngrid
+    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz
     use fields, only : volg
     use timer
     implicit none

--- a/unit-tests/test_parcel_correction.f90
+++ b/unit-tests/test_parcel_correction.f90
@@ -13,7 +13,7 @@ program test_parcel_correction
     use parcel_interpl, only : vol2grid, vol2grid_timer
     use parcel_ellipse, only : get_ab
     use options, only : parcel
-    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz, ngrid
+    use parameters, only : lower, extent, update_parameters, vcell, dx, nx, nz
     use fields, only : volg
     use timer
 

--- a/unit-tests/test_tri_inversion.f90
+++ b/unit-tests/test_tri_inversion.f90
@@ -8,7 +8,7 @@ program test_tri_inversion
     use constants, only : pi, twopi, one, zero, two, four, f12, f32
     use parcel_container
     use tri_inversion
-    use parameters, only : extent, lower, update_parameters, vcell, dx, nx, nz, hl, ncell
+    use parameters, only : extent, lower, update_parameters, dx, nx, nz, hl, ncell
     use timer
     implicit none
 
@@ -65,7 +65,7 @@ program test_tri_inversion
     max_err = zero
 
     ! absolute error (reference obtained from David's program (tri_inversion.f90)
-    max_err = max(max_err, abs(maxval(abs(velog(0:nz, :, 1) - ue)) - 0.72528494909253993d0))
+    max_err = max(max_err, abs(maxval(abs(velog(0:nz, :, 1) - ue)) - 0.50258439839100966d0))
     max_err = max(max_err, abs(maxval(abs(velog(0:nz, :, 2) - we)) - 0.000039197805283164300d0))
 
 
@@ -76,7 +76,7 @@ program test_tri_inversion
     zz = dsqrt(sum(we(1:nz-1, :)) / dble(ncell))
 
     ! referene obtaind from David's program (tri_inversion.f90)
-    max_err = max(max_err, abs(xx - 0.1203711977266676d0))
+    max_err = max(max_err, abs(xx - 0.3473213454049072d0))
     max_err = max(max_err, abs(zz - 0.0000181041574751d0))
 
     call print_result_dp('Test tri-inversion', max_err)


### PR DESCRIPTION
`-Wno-maybe-unitialized` is due to `character(:), allocatable` (see also https://stackoverflow.com/questions/61728557/fortran-program-using-character-variable-with-allocatable-length-always-shows-a)