### PR TITLE
Extrapolate to halo grid points for vorticity

### DIFF
--- a/src/parcels/parcel_interpl.f90
+++ b/src/parcels/parcel_interpl.f90
@@ -234,6 +234,12 @@ module parcel_interpl
             tbuoyg(nz-1, :) = tbuoyg(nz-1, :) + tbuoyg(nz+1, :)
             ! exclude halo cells to avoid division by zero
             vortg(0:nz, :) = vortg(0:nz, :) / volg(0:nz, :)
+
+            ! extrapolate to halo grid points (since halo grid points
+            ! are used to get u_z = w_x - zeta)
+            vortg(-1,   :) = two * vortg(0,  :) - vortg(1,    :)
+            vortg(nz+1, :) = two * vortg(nz, :) - vortg(nz-1, :)
+
 #ifndef ENABLE_DRY_MODE
             dbuoyg(0:nz, :) = dbuoyg(0:nz, :) / volg(0:nz, :)
 #endif


### PR DESCRIPTION
As discussed in #176, we need to extrapolate to the halo grid points for the vorticity since it is used to compute `u_z`, i.e.
```
velgradg(:, :, 2) = velgradg(:, :, 3) - vortg(:, :)
```
in `vor2vel`.