### PR TITLE
Use proper interpolation name

### DIFF
--- a/src/parcels/parcel_correction.f90
+++ b/src/parcels/parcel_correction.f90
@@ -13,7 +13,7 @@ module parcel_correction
     use stafft
     use deriv1d
 
-    use parcel_interpl, only : trilinear, ngp, vol2grid
+    use parcel_interpl, only : bilinear, ngp, vol2grid
     use parcel_bc
     use omp_lib
 
@@ -187,7 +187,7 @@ module parcel_correction
         !$omp parallel default(shared)
         !$omp do private(n, l, is, js, weights)
         do n = 1, n_parcels
-            call trilinear(parcels%position(n, :), is, js, weights)
+            call bilinear(parcels%position(n, :), is, js, weights)
 
             do l = 1, ngp
                 parcels%position(n, 1) = parcels%position(n, 1)             &
@@ -226,7 +226,7 @@ module parcel_correction
         !$omp do private(n, is, js, weights, x1_fpos, x2_fpos, shift_x1, shift_x2, lim_x1, lim_x2)
         do n = 1, n_parcels
 
-            call trilinear(parcels%position(n, :), is, js, weights)
+            call bilinear(parcels%position(n, :), is, js, weights)
 
             x1_fpos=weights(2)+weights(4) ! fractional position along x1
             x2_fpos=weights(3)+weights(4) ! fractional position along x2

--- a/src/parcels/parcel_init.f90
+++ b/src/parcels/parcel_init.f90
@@ -7,7 +7,7 @@ module parcel_init
     use parcel_container, only : parcels, n_parcels
     use parcel_ellipse, only : get_ab, get_B22, get_eigenvalue
     use parcel_split, only : split_ellipses
-    use parcel_interpl, only : trilinear, ngp
+    use parcel_interpl, only : bilinear, ngp
     use parameters, only : update_parameters,   &
                            dx, vcell, ncell,    &
                            extent, lower, nx, nz
@@ -168,7 +168,7 @@ module parcel_init
         end subroutine init_refine
 
 
-        ! Precompute weights, indices of trilinear
+        ! Precompute weights, indices of bilinear
         ! interpolation and "apar"
         subroutine alloc_and_precompute
             double precision :: resi(0:nz, 0:nx-1), rsum
@@ -185,7 +185,7 @@ module parcel_init
             !$omp parallel do default(shared) private(n, l) reduction(+:resi)
             do n = 1, n_parcels
                 ! get interpolation weights and mesh indices
-                call trilinear(parcels%position(n, :), is(n, :), js(n, :), weights(n, :))
+                call bilinear(parcels%position(n, :), is(n, :), js(n, :), weights(n, :))
 
                 do l = 1, ngp
                     resi(js(n, l), is(n, l)) = resi(js(n, l), is(n, l)) + weights(n, l)

--- a/src/parcels/parcel_interpl.f90
+++ b/src/parcels/parcel_interpl.f90
@@ -61,7 +61,7 @@ module parcel_interpl
                     call apply_periodic_bc(points(p, :))
 
                     ! get interpolation weights and mesh indices
-                    call trilinear(points(p, :), is, js, weights)
+                    call bilinear(points(p, :), is, js, weights)
 
                     do l = 1, ngp
                         volg(js(l), is(l)) = volg(js(l), is(l)) &
@@ -117,7 +117,7 @@ module parcel_interpl
                         call apply_periodic_bc(points(p, :))
 
                         ! get interpolation weights and mesh indices
-                        call trilinear(points(p, :), is, js, weights)
+                        call bilinear(points(p, :), is, js, weights)
 
                         do l = 1, ngp
                             sym_volg(js(l), is(l)) = sym_volg(js(l), is(l)) &
@@ -196,7 +196,7 @@ module parcel_interpl
                     call apply_periodic_bc(points(p, :))
 
                     ! get interpolation weights and mesh indices
-                    call trilinear(points(p, :), is, js, weights)
+                    call bilinear(points(p, :), is, js, weights)
 
                     ! loop over grid points which are part of the interpolation
                     ! the weight is halved due to 2 points per ellipse
@@ -341,7 +341,7 @@ module parcel_interpl
                     call apply_periodic_bc(points(p, :))
 
                     ! get interpolation weights and mesh indices
-                    call trilinear(points(p, :), is, js, weights)
+                    call bilinear(points(p, :), is, js, weights)
 
                     ! loop over grid points which are part of the interpolation
                     do l = 1, ngp
@@ -389,7 +389,7 @@ module parcel_interpl
         ! @param[out] ii horizontal grid points for interoplation
         ! @param[out] jj vertical grid points for interpolation
         ! @param[out] ww interpolation weights
-        subroutine trilinear(pos, ii, jj, ww)
+        subroutine bilinear(pos, ii, jj, ww)
             double precision, intent(in)  :: pos(2)
             integer,          intent(out) :: ii(4), jj(4)
             double precision, intent(out) :: ww(4)
@@ -421,6 +421,6 @@ module parcel_interpl
             ! account for x periodicity
             call periodic_index_shift(ii)
 
-        end subroutine trilinear
+        end subroutine bilinear
 
 end module parcel_interpl


### PR DESCRIPTION
We currently use the name `trilinear` in 2D, but it should be named `bilinear` instead.