### PR TITLE
Use heap memory

### DIFF
--- a/analyse/genspec.f90
+++ b/analyse/genspec.f90
@@ -226,7 +226,7 @@ program genspec
         subroutine write_spectrum
             logical                   :: exists = .false.
             character(:), allocatable :: fname
-            integer                   :: pos, kx, kz
+            integer                   :: pos
 
             ! 1 October 2021
             ! https://stackoverflow.com/questions/36731707/fortran-how-to-remove-file-extension-from-character

--- a/src/2d/parcels/parcel_init.f90
+++ b/src/2d/parcels/parcel_init.f90
@@ -263,13 +263,15 @@ module parcel_init
         ! Precompute weights, indices of bilinear
         ! interpolation and "apar"
         subroutine alloc_and_precompute
-            double precision :: resi(0:nz, 0:nx-1), rsum
+            double precision, allocatable :: resi(:, :)
+            double precision :: rsum
             integer          :: n, l
 
             allocate(apar(n_parcels))
             allocate(weights(ngp, n_parcels))
             allocate(is(ngp, n_parcels))
             allocate(js(ngp, n_parcels))
+            allocate(resi(0:nz, 0:nx-1))
 
             ! Compute mean parcel density:
             resi = zero
@@ -299,6 +301,8 @@ module parcel_init
                 apar(n) = one / rsum
             enddo
             !$omp end parallel do
+
+            deallocate(resi)
 
         end subroutine alloc_and_precompute
 


### PR DESCRIPTION
For large problem sizes OpenMP has issues, that is, one gets a segmentation fault since it cannot handle the size on stack. We need to use heap memory.