### PR TITLE
Enable Python

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,13 @@
 SUBDIRS =		\
 	src		\
 	unit-tests	\
-	python-scripts	\
  	analyse		\
- 	models		\
-	run-script
+ 	models
 
+if ENABLE_PYTHON
+SUBDIRS += python-scripts	\
+	   run-script
+endif
 
 # 3 November 2021
 # https://stackoverflow.com/questions/16657991/glibtoolize-on-macos-tells-me-to-consider-adding-i-m4-to-aclocal-amflags-but
@@ -21,8 +23,10 @@ dataroot_DATA = 				\
 	examples/robert2d-one-uniform.nml	\
 	examples/robert2d-two-gaussians.nml	\
 	examples/straka2d.nml			\
-	examples/taylorgreen2d.nml		\
-	examples/write_moist_setup.py
+	examples/taylorgreen2d.nml
+
+if ENABLE_PYTHON
+dataroot_DATA += examples/write_moist_setup.py
 
 
 # make python script an executable script
@@ -36,3 +40,4 @@ install-exec-hook:
 	chmod 755 $(bindir)/subgrid_2d_generalised.py
 	chmod 755 $(bindir)/compare_results.py
 	chmod 755 $(bindir)/plot_slices.py
+endif

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ $ conda create --name <env> python=3.9.9 --file requirements.txt
 ```
 where `<env>` is the name of the environment. The file `requirements.txt` is contained in the root directory of EPIC.
 
+**Note:** In order to install the Python scripts you need to configure with `--enable-python`.
+
 We further provide Fortran analysis scripts. These are:
 * genspec (power spectrum analysis)
 

--- a/configure.ac
+++ b/configure.ac
@@ -35,24 +35,90 @@ AC_CONFIG_FILES([
     run-script/Makefile
 ])
 
+#######################################################################################
+##
+## "--with" flags
+##
+
+## define some default search paths
+declare default_lib_paths="/lib:/usr/lib:/lib64:/usr/lib64:/usr/local/lib:$LD_LIBRARY_PATH"
+declare default_include_paths="/usr/include:/usr/local/lib:$C_INCLUDE_PATH:$CPLUS_INCLUDE_PATH"
+
+# 11 March 2021
+# https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/External-Software.html
+AC_ARG_WITH([netcdf],
+            [AS_HELP_STRING([--with-netcdf=<path>], [path to netcdf library @<:@default=$NETCDF_DIR@:>@])],
+            [NETCDF_DIR=$withval],
+            [])
+
+if test -n "${NETCDF_DIR}"; then
+    FCFLAGS="$FCFLAGS -I$NETCDF_DIR/include"
+    LDFLAGS="$LDFLAGS -L$NETCDF_DIR/lib"
+    LIBS="$LIBS -lnetcdff -lnetcdf"
+else
+    for path in ${default_lib_paths//:/ }; do
+        AC_MSG_CHECKING([for netcdf Fortran libraries in $path])
+        if test -e "$path/libnetcdff.a"; then
+            NETCDF_LIBRARY_DIR="$path"
+            AC_MSG_RESULT([yes])
+            break
+        fi
+        AC_MSG_RESULT([no])
+    done
+
+    for path in ${default_include_paths//:/ }; do
+        AC_MSG_CHECKING([for netcdf Fortran modules in $path])
+        if test -e "$path/netcdf.mod"; then
+            NETCDF_INCLUDE_DIR="$path"
+            AC_MSG_RESULT([yes])
+            break
+        fi
+        AC_MSG_RESULT([no])
+    done
+
+    if test -n "${NETCDF_LIBRARY_DIR}" && test -n "${NETCDF_INCLUDE_DIR}"; then
+        FCFLAGS="$FCFLAGS -I$NETCDF_INCLUDE_DIR"
+        LDFLAGS="$LDFLAGS -L$NETCDF_LIBRARY_DIR"
+        LIBS="$LIBS -lnetcdff -lnetcdf"
+    else
+        AC_MSG_ERROR([Cannot find netcdf.
+                    Please export the environment variable NETCDF_DIR pointing
+                    to the root directory of netcdf.])
+    fi
+fi
+
+# 11 March 2021
+# https://github.com/PhysicsofFluids/AFiD/blob/master/configure.ac#L139
+AC_MSG_CHECKING([whether we can compile a netcdf program])
+AC_LINK_IFELSE(
+[AC_LANG_PROGRAM([], [
+    use netcdf
+    implicit none])],
+[netcdf_found=yes],
+[netcdf_found=no AC_MSG_ERROR([Cannot compile a netcdf program])])
+AC_MSG_RESULT([$netcdf_found])
 
 #######################################################################################
 ##
-## check Python installation
+## "--enable" flags
+##
+
+##
+## Python
 ##
 ## # 23 March 2021
 ## https://askubuntu.com/questions/29370/how-to-check-if-a-command-succeeded
 ## https://gitlab.psi.ch/H5hut/src/-/blob/master/configure.ac
 ##
 
-DISABLE_PYTHON_CHECK='no'
-AC_ARG_ENABLE([python-check],
-              [AS_HELP_STRING([--disable-python-check], [disable Python checke (default=no)])],
-              [DISABLE_PYTHON_CHECK=$disableval])
+ENABLE_PYTHON='no'
+AC_ARG_ENABLE([python],
+              [AS_HELP_STRING([--enable-python], [enable Python (default=no)])],
+              [ENABLE_PYTHON=$enableval])
 
-AM_CONDITIONAL([DISABLE_PYTHON_CHECK], [test "$DISABLE_PYTHON_CHECK" = "yes"])
+AM_CONDITIONAL([ENABLE_PYTHON], [test "$ENABLE_PYTHON" = "yes"])
 
-if test "x$DISABLE_PYTHON_CHECK" = "xno"; then
+if test "x$ENABLE_PYTHON" = "xyes"; then
     AM_PATH_PYTHON([3.0])
     #
     # argparse
@@ -175,73 +241,9 @@ if test "x$DISABLE_PYTHON_CHECK" = "xno"; then
     fi
 fi
 
-#######################################################################################
-##
-## "--with" flags
-##
-
-## define some default search paths
-declare default_lib_paths="/lib:/usr/lib:/lib64:/usr/lib64:/usr/local/lib:$LD_LIBRARY_PATH"
-declare default_include_paths="/usr/include:/usr/local/lib:$C_INCLUDE_PATH:$CPLUS_INCLUDE_PATH"
-
-# 11 March 2021
-# https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/External-Software.html
-AC_ARG_WITH([netcdf],
-            [AS_HELP_STRING([--with-netcdf=<path>], [path to netcdf library @<:@default=$NETCDF_DIR@:>@])],
-            [NETCDF_DIR=$withval],
-            [])
-
-if test -n "${NETCDF_DIR}"; then
-    FCFLAGS="$FCFLAGS -I$NETCDF_DIR/include"
-    LDFLAGS="$LDFLAGS -L$NETCDF_DIR/lib"
-    LIBS="$LIBS -lnetcdff -lnetcdf"
-else
-    for path in ${default_lib_paths//:/ }; do
-        AC_MSG_CHECKING([for netcdf Fortran libraries in $path])
-        if test -e "$path/libnetcdff.a"; then
-            NETCDF_LIBRARY_DIR="$path"
-            AC_MSG_RESULT([yes])
-            break
-        fi
-        AC_MSG_RESULT([no])
-    done
-
-    for path in ${default_include_paths//:/ }; do
-        AC_MSG_CHECKING([for netcdf Fortran modules in $path])
-        if test -e "$path/netcdf.mod"; then
-            NETCDF_INCLUDE_DIR="$path"
-            AC_MSG_RESULT([yes])
-            break
-        fi
-        AC_MSG_RESULT([no])
-    done
-
-    if test -n "${NETCDF_LIBRARY_DIR}" && test -n "${NETCDF_INCLUDE_DIR}"; then
-        FCFLAGS="$FCFLAGS -I$NETCDF_INCLUDE_DIR"
-        LDFLAGS="$LDFLAGS -L$NETCDF_LIBRARY_DIR"
-        LIBS="$LIBS -lnetcdff -lnetcdf"
-    else
-        AC_MSG_ERROR([Cannot find netcdf.
-                    Please export the environment variable NETCDF_DIR pointing
-                    to the root directory of netcdf.])
-    fi
-fi
-
-# 11 March 2021
-# https://github.com/PhysicsofFluids/AFiD/blob/master/configure.ac#L139
-AC_MSG_CHECKING([whether we can compile a netcdf program])
-AC_LINK_IFELSE(
-[AC_LANG_PROGRAM([], [
-    use netcdf
-    implicit none])],
-[netcdf_found=yes],
-[netcdf_found=no AC_MSG_ERROR([Cannot compile a netcdf program])])
-AC_MSG_RESULT([$netcdf_found])
-
-#######################################################################################
-##
-## "--enable" flags
-##
+#
+#
+#
 
 ENABLE_3D='yes'
 AC_ARG_ENABLE([3d],

--- a/python-scripts/Makefile.am
+++ b/python-scripts/Makefile.am
@@ -1,3 +1,4 @@
+if ENABLE_PYTHON
 SUBDIRS = tools
 
 animate_parcels_PYTHON = animate-parcels.py
@@ -23,3 +24,4 @@ compare_resultsdir = $(bindir)
 
 plot_slices_PYTHON = plot_slices.py
 plot_slicesdir = $(bindir)
+endif

--- a/run-script/Makefile.am
+++ b/run-script/Makefile.am
@@ -1,6 +1,8 @@
+if ENABLE_PYTHON
 dataroot_DATA = 				\
 	template.config				\
 	taylor_green.json
 
 epic_run_PYTHON = epic-run.py
 epic_rundir = $(bindir)
+endif


### PR DESCRIPTION
Replace `--disable-python-check` with `--enable-python`. The current version causes an error when doing `make install` and Python is not available.