### PR TITLE
Dynamic maximum number of parcels

### DIFF
--- a/src/2d/parcels/parcel_init.f90
+++ b/src/2d/parcels/parcel_init.f90
@@ -3,14 +3,14 @@
 ! =============================================================================
 module parcel_init
     use options, only : parcel, output, verbose, field_tol
-    use constants, only : zero, two, one, f12, max_num_parcels
+    use constants, only : zero, two, one, f12
     use parcel_container, only : parcels, n_parcels
     use parcel_ellipse, only : get_ab, get_B22, get_eigenvalue
     use parcel_split, only : split_ellipses
     use parcel_interpl, only : bilinear, ngp
-    use parameters, only : update_parameters,   &
-                           dx, vcell, ncell,    &
-                           extent, lower, nx, nz
+    use parameters, only : dx, vcell, ncell,        &
+                           extent, lower, nx, nz,   &
+                           max_num_parcels
     use netcdf_reader
     use timer, only : start_timer, stop_timer
     use omp_lib
@@ -44,17 +44,9 @@ module parcel_init
             character(*),     intent(in) :: fname
             double precision, intent(in) :: tol
             double precision             :: lam, ratio
-            integer                      :: n, ncells(2)
+            integer                      :: n
 
             call start_timer(init_timer)
-
-            ! read domain dimensions
-            call read_netcdf_domain(fname, lower, extent, ncells)
-            nx = ncells(1)
-            nz = ncells(2)
-
-            ! update global parameters
-            call update_parameters
 
             ! set the number of parcels (see parcels.f90)
             ! we use "n_per_cell" parcels per grid cell

--- a/src/2d/parcels/parcel_merge.f90
+++ b/src/2d/parcels/parcel_merge.f90
@@ -4,8 +4,7 @@
 ! =============================================================================
 module parcel_merge
     use parcel_nearest
-    use constants, only : pi, zero, one, two, four    &
-                        , max_num_parcels
+    use constants, only : pi, zero, one, two, four
     use parcel_container, only : parcel_container_type  &
                                , n_parcels              &
                                , parcel_replace         &

--- a/src/2d/parcels/parcel_nearest.f90
+++ b/src/2d/parcels/parcel_nearest.f90
@@ -2,9 +2,9 @@
 !               Finds the parcels nearest every "small" parcel
 !==============================================================================
 module parcel_nearest
-    use constants, only : pi, f12, max_num_parcels
+    use constants, only : pi, f12
     use parcel_container, only : parcels, n_parcels, get_delx
-    use parameters, only : dx, dxi, vcell, hli, lower, extent, ncell, nx, nz, vmin
+    use parameters, only : dx, dxi, vcell, hli, lower, extent, ncell, nx, nz, vmin, max_num_parcels
     use options, only : parcel
     use timer, only : start_timer, stop_timer
 
@@ -16,21 +16,21 @@ module parcel_nearest
 
     !Used for searching for possible parcel merger:
     integer, allocatable :: nppc(:), kc1(:),kc2(:)
-    integer :: loca(max_num_parcels)
-    integer :: node(max_num_parcels)
+    integer, allocatable :: loca(:)
+    integer, allocatable :: node(:)
 
     ! Logicals used to determine which mergers are executed
     ! Integers above could be reused for this, but this would
     ! make the algorithm less readable
-    logical :: l_leaf(max_num_parcels)
-    logical :: l_available(max_num_parcels)
-    logical :: l_first_merged(max_num_parcels) ! indicates parcels merged in first stage
+    logical, allocatable :: l_leaf(:)
+    logical, allocatable :: l_available(:)
+    logical, allocatable :: l_first_merged(:) ! indicates parcels merged in first stage
 
 #ifndef NDEBUG
     ! Logicals that are only needed for sanity checks
-    logical :: l_merged(max_num_parcels)! SANITY CHECK ONLY
-    logical :: l_small(max_num_parcels) ! SANITY CHECK ONLY
-    logical :: l_close(max_num_parcels) ! SANITY CHECK ONLY
+    logical, allocatable :: l_merged(:)! SANITY CHECK ONLY
+    logical, allocatable :: l_small(:) ! SANITY CHECK ONLY
+    logical, allocatable :: l_close(:) ! SANITY CHECK ONLY
 #endif
 
     logical :: l_continue_iteration, l_do_merge
@@ -63,6 +63,16 @@ module parcel_nearest
                 allocate(nppc(ncell))
                 allocate(kc1(ncell))
                 allocate(kc2(ncell))
+                allocate(loca(max_num_parcels))
+                allocate(node(max_num_parcels))
+                allocate(l_leaf(max_num_parcels))
+                allocate(l_available(max_num_parcels))
+                allocate(l_first_merged(max_num_parcels))
+#ifndef NDEBUG
+                allocate(l_merged(max_num_parcels))
+                allocate(l_small(max_num_parcels))
+                allocate(l_close(max_num_parcels))
+#endif
             endif
 
             nmerge = 0

--- a/src/2d/parcels/parcel_netcdf.f90
+++ b/src/2d/parcels/parcel_netcdf.f90
@@ -1,10 +1,10 @@
 module parcel_netcdf
-    use constants, only : max_num_parcels, one
+    use constants, only : one
     use netcdf_utils
     use netcdf_writer
     use netcdf_reader
     use parcel_container, only : parcels, n_parcels
-    use parameters, only : nx, nz, extent, lower, update_parameters
+    use parameters, only : nx, nz, extent, lower, max_num_parcels
     use config, only : package_version, cf_version
     use timer, only : start_timer, stop_timer
     use iomanip, only : zfill
@@ -231,14 +231,6 @@ module parcel_netcdf
             call start_timer(parcel_io_timer)
 
             call open_netcdf_file(fname, NF90_NOWRITE, ncid)
-
-            ! read domain dimensions
-            call get_netcdf_box(ncid, lower, extent, ncells)
-            nx = ncells(1)
-            nz = ncells(2)
-
-            ! update global parameters
-            call update_parameters
 
             call get_num_parcels(ncid, n_parcels)
 

--- a/src/2d/utils/options.f90
+++ b/src/2d/utils/options.f90
@@ -52,7 +52,7 @@ module options
     ! parcel options
     !
     type parcel_type
-        integer          :: size_factor      = 3        ! factor to increase max. number of parcels
+        double precision :: size_factor      = 1.0d0    ! factor to increase max. number of parcels
         integer          :: n_per_cell       = 9        ! number of parcels per cell (need to be a square)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/2d/utils/options.f90
+++ b/src/2d/utils/options.f90
@@ -52,6 +52,7 @@ module options
     ! parcel options
     !
     type parcel_type
+        integer          :: size_factor      = 3        ! factor to increase max. number of parcels
         integer          :: n_per_cell       = 9        ! number of parcels per cell (need to be a square)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/2d/utils/options.f90
+++ b/src/2d/utils/options.f90
@@ -130,6 +130,7 @@ module options
             call write_netcdf_attribute(ncid, "allow_larger_anisotropy", &
                                                allow_larger_anisotropy)
 
+            call write_netcdf_attribute(ncid, "size_factor", parcel%size_factor)
             call write_netcdf_attribute(ncid, "n_per_cell", parcel%n_per_cell)
             call write_netcdf_attribute(ncid, "lambda_max", parcel%lambda_max)
             call write_netcdf_attribute(ncid, "min_vratio", parcel%min_vratio)

--- a/src/2d/utils/parameters.f90
+++ b/src/2d/utils/parameters.f90
@@ -57,6 +57,9 @@ module parameters
     ! maximum volume
     double precision :: vmax
 
+    ! maximum number of allowed parcels
+    integer :: max_num_parcels
+
     contains
 
     ! Update all parameters according to the
@@ -97,6 +100,8 @@ module parameters
 
         vmin = vcell / parcel%min_vratio
         vmax = vcell / parcel%max_vratio
+
+        max_num_parcels = nx * nz * parcel%n_per_cell * parcel%size_factor
 
     end subroutine update_parameters
 end module parameters

--- a/src/2d/utils/parameters.f90
+++ b/src/2d/utils/parameters.f90
@@ -101,7 +101,7 @@ module parameters
         vmin = vcell / parcel%min_vratio
         vmax = vcell / parcel%max_vratio
 
-        max_num_parcels = nx * nz * parcel%n_per_cell * parcel%size_factor
+        max_num_parcels = int(nx * nz * parcel%min_vratio * parcel%size_factor)
 
     end subroutine update_parameters
 end module parameters

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -5,6 +5,7 @@
 module parcel_container
     use options, only : verbose
     use parameters, only : extent, hli, center, lower, upper
+    use parcel_ellipsoid, only : parcel_ellispoid_allocate, parcel_ellispoid_deallocate
     implicit none
 
     integer :: n_parcels
@@ -122,6 +123,7 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             allocate(parcels%humidity(num))
 #endif
+            call parcel_ellispoid_allocate
         end subroutine parcel_alloc
 
         ! Deallocate parcel memory
@@ -134,6 +136,7 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             deallocate(parcels%humidity)
 #endif
+            call parcel_ellispoid_deallocate
         end subroutine parcel_dealloc
 
 end module parcel_container

--- a/src/3d/parcels/parcel_container.f90
+++ b/src/3d/parcels/parcel_container.f90
@@ -5,7 +5,7 @@
 module parcel_container
     use options, only : verbose
     use parameters, only : extent, hli, center, lower, upper
-    use parcel_ellipsoid, only : parcel_ellispoid_allocate, parcel_ellispoid_deallocate
+    use parcel_ellipsoid, only : parcel_ellipsoid_allocate, parcel_ellipsoid_deallocate
     implicit none
 
     integer :: n_parcels
@@ -123,7 +123,7 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             allocate(parcels%humidity(num))
 #endif
-            call parcel_ellispoid_allocate
+            call parcel_ellipsoid_allocate
         end subroutine parcel_alloc
 
         ! Deallocate parcel memory
@@ -136,7 +136,7 @@ module parcel_container
 #ifndef ENABLE_DRY_MODE
             deallocate(parcels%humidity)
 #endif
-            call parcel_ellispoid_deallocate
+            call parcel_ellipsoid_deallocate
         end subroutine parcel_dealloc
 
 end module parcel_container

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -14,8 +14,8 @@ module parcel_ellipsoid
                         , two   &
                         , three &
                         , five  &
-                        , seven &
-                        , max_num_parcels
+                        , seven
+    use parameters, only : max_num_parcels
     use jacobi
     implicit none
 
@@ -26,12 +26,21 @@ module parcel_ellipsoid
     double precision, parameter :: costheta(4) = dcos((/fpi4, f3pi4, f5pi4, f7pi4/))
     double precision, parameter :: sintheta(4) = dsin((/fpi4, f3pi4, f5pi4, f7pi4/))
 
-    double precision :: Vetas(3, max_num_parcels), &
-                        Vtaus(3, max_num_parcels)
+    double precision, allocatable :: Vetas(:, :), Vtaus(:, :)
 
-    private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_upper_triangular
+    private :: rho, f3pi4, f5pi4, f7pi4, costheta, sintheta, get_upper_triangular, Vetas, Vtaus
 
     contains
+
+        subroutine parcel_ellispoid_allocate
+            allocate(Vetas(3, max_num_parcels))
+            allocate(Vtaus(3, max_num_parcels))
+        end subroutine parcel_ellispoid_allocate
+
+        subroutine parcel_ellispoid_deallocate
+            deallocate(Vetas)
+            deallocate(Vtaus)
+        end subroutine parcel_ellispoid_deallocate
 
         ! Obtain the parcel shape matrix.
         ! @param[in] B = (B11, B12, B13, B22, B23)

--- a/src/3d/parcels/parcel_ellipsoid.f90
+++ b/src/3d/parcels/parcel_ellipsoid.f90
@@ -32,15 +32,15 @@ module parcel_ellipsoid
 
     contains
 
-        subroutine parcel_ellispoid_allocate
+        subroutine parcel_ellipsoid_allocate
             allocate(Vetas(3, max_num_parcels))
             allocate(Vtaus(3, max_num_parcels))
-        end subroutine parcel_ellispoid_allocate
+        end subroutine parcel_ellipsoid_allocate
 
-        subroutine parcel_ellispoid_deallocate
+        subroutine parcel_ellipsoid_deallocate
             deallocate(Vetas)
             deallocate(Vtaus)
-        end subroutine parcel_ellispoid_deallocate
+        end subroutine parcel_ellipsoid_deallocate
 
         ! Obtain the parcel shape matrix.
         ! @param[in] B = (B11, B12, B13, B22, B23)

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -3,15 +3,14 @@
 ! =============================================================================
 module parcel_init
     use options, only : parcel, output, verbose, field_tol
-    use constants, only : zero, two, one, f12, f13, f23, max_num_parcels
+    use constants, only : zero, two, one, f12, f13, f23
     use parcel_container, only : parcels, n_parcels
     use parcel_ellipsoid, only : get_abc, get_eigenvalues
     use parcel_split_mod, only : parcel_split
     use parcel_interpl, only : trilinear, ngp
-    use netcdf_reader, only : read_netcdf_domain
-    use parameters, only : update_parameters,   &
-                           dx, vcell, ncell,    &
-                           extent, lower, nx, ny, nz
+    use parameters, only : dx, vcell, ncell,            &
+                           extent, lower, nx, ny, nz,   &
+                           max_num_parcels
     use timer, only : start_timer, stop_timer
     use omp_lib
     implicit none
@@ -45,18 +44,9 @@ module parcel_init
             character(*),     intent(in) :: fname
             double precision, intent(in) :: tol
             double precision             :: lam, l23
-            integer                      :: n, ncells(3)
+            integer                      :: n
 
             call start_timer(init_timer)
-
-            ! read domain dimensions
-            call read_netcdf_domain(fname, lower, extent, ncells)
-            nx = ncells(1)
-            ny = ncells(2)
-            nz = ncells(3)
-
-            ! update global parameters
-            call update_parameters
 
             ! set the number of parcels (see parcels.f90)
             ! we use "n_per_cell" parcels per grid cell

--- a/src/3d/parcels/parcel_merge.f90
+++ b/src/3d/parcels/parcel_merge.f90
@@ -4,8 +4,7 @@
 ! =============================================================================
 module parcel_merge
     use parcel_nearest
-    use constants, only : pi, zero, one, two, five, f13 &
-                        , max_num_parcels
+    use constants, only : pi, zero, one, two, five, f13
     use parcel_container, only : parcel_container_type  &
                                , n_parcels              &
                                , parcel_replace         &

--- a/src/3d/parcels/parcel_nearest.f90
+++ b/src/3d/parcels/parcel_nearest.f90
@@ -2,9 +2,9 @@
 !               Finds the parcels nearest every "small" parcel
 !==============================================================================
 module parcel_nearest
-    use constants, only : pi, f12, max_num_parcels
+    use constants, only : pi, f12
     use parcel_container, only : parcels, n_parcels, get_delx, get_dely
-    use parameters, only : dx, dxi, vcell, hli, lower, extent, ncell, nx, ny, nz, vmin
+    use parameters, only : dx, dxi, vcell, hli, lower, extent, ncell, nx, ny, nz, vmin, max_num_parcels
     use options, only : parcel
     use timer, only : start_timer, stop_timer
 
@@ -16,21 +16,21 @@ module parcel_nearest
 
     !Used for searching for possible parcel merger:
     integer, allocatable :: nppc(:), kc1(:), kc2(:)
-    integer :: loca(max_num_parcels)
-    integer :: node(max_num_parcels)
+    integer, allocatable :: loca(:)
+    integer, allocatable :: node(:)
 
     ! Logicals used to determine which mergers are executed
     ! Integers above could be reused for this, but this would
     ! make the algorithm less readable
-    logical :: l_leaf(max_num_parcels)
-    logical :: l_available(max_num_parcels)
-    logical :: l_first_merged(max_num_parcels) ! indicates parcels merged in first stage
+    logical, allocatable :: l_leaf(:)
+    logical, allocatable :: l_available(:)
+    logical, allocatable :: l_first_merged(:) ! indicates parcels merged in first stage
 
 #ifndef NDEBUG
     ! Logicals that are only needed for sanity checks
-    logical :: l_merged(max_num_parcels)! SANITY CHECK ONLY
-    logical :: l_small(max_num_parcels) ! SANITY CHECK ONLY
-    logical :: l_close(max_num_parcels) ! SANITY CHECK ONLY
+    logical, allocatable :: l_merged(:)! SANITY CHECK ONLY
+    logical, allocatable :: l_small(:) ! SANITY CHECK ONLY
+    logical, allocatable :: l_close(:) ! SANITY CHECK ONLY
 #endif
 
     logical :: l_continue_iteration, l_do_merge
@@ -63,6 +63,16 @@ module parcel_nearest
                 allocate(nppc(ncell))
                 allocate(kc1(ncell))
                 allocate(kc2(ncell))
+                allocate(loca(max_num_parcels))
+                allocate(node(max_num_parcels))
+                allocate(l_leaf(max_num_parcels))
+                allocate(l_available(max_num_parcels))
+                allocate(l_first_merged(max_num_parcels))
+#ifndef NDEBUG
+                allocate(l_merged(max_num_parcels))
+                allocate(l_small(max_num_parcels))
+                allocate(l_close(max_num_parcels))
+#endif
             endif
 
             nmerge = 0

--- a/src/3d/parcels/parcel_netcdf.f90
+++ b/src/3d/parcels/parcel_netcdf.f90
@@ -1,10 +1,10 @@
 module parcel_netcdf
-    use constants, only : max_num_parcels, one
+    use constants, only : one
     use netcdf_utils
     use netcdf_writer
     use netcdf_reader
     use parcel_container, only : parcels, n_parcels
-    use parameters, only : nx, ny, nz, extent, lower, update_parameters
+    use parameters, only : nx, ny, nz, extent, lower, max_num_parcels
     use config, only : package_version, cf_version
     use timer, only : start_timer, stop_timer
     use iomanip, only : zfill
@@ -289,22 +289,12 @@ module parcel_netcdf
 
         subroutine read_netcdf_parcels(fname)
             character(*),     intent(in) :: fname
-            integer                      :: ncells(3)
             logical                      :: l_valid = .false.
             integer                      :: cnt(2), start(2)
 
             call start_timer(parcel_io_timer)
 
             call open_netcdf_file(fname, NF90_NOWRITE, ncid)
-
-            ! read domain dimensions
-            call get_netcdf_box(ncid, lower, extent, ncells)
-            nx = ncells(1)
-            ny = ncells(2)
-            nz = ncells(3)
-
-            ! update global parameters
-            call update_parameters
 
             call get_num_parcels(ncid, n_parcels)
 

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -142,6 +142,7 @@ module options
             call write_netcdf_attribute(ncid, "allow_larger_anisotropy", &
                                                allow_larger_anisotropy)
 
+            call write_netcdf_attribute(ncid, "size_factor", parcel%size_factor)
             call write_netcdf_attribute(ncid, "n_per_cell", parcel%n_per_cell)
             call write_netcdf_attribute(ncid, "lambda_max", parcel%lambda_max)
             call write_netcdf_attribute(ncid, "min_vratio", parcel%min_vratio)

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -64,6 +64,7 @@ module options
     ! parcel options
     !
     type parcel_type
+        integer          :: size_factor      = 3        ! factor to increase max. number of parcels
         integer          :: n_per_cell       = 9        ! number of parcels per cell (need to be a square)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/3d/utils/options.f90
+++ b/src/3d/utils/options.f90
@@ -64,7 +64,7 @@ module options
     ! parcel options
     !
     type parcel_type
-        integer          :: size_factor      = 3        ! factor to increase max. number of parcels
+        double precision :: size_factor      = 1.0d0    ! factor to increase max. number of parcels
         integer          :: n_per_cell       = 9        ! number of parcels per cell (need to be a square)
         double precision :: lambda_max       = four     ! max. ellipse aspect ratio a/b
         double precision :: min_vratio       = 40.0d0   ! minimum ratio of grid cell volume / parcel volume

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -106,7 +106,7 @@ module parameters
         vmin = vcell / parcel%min_vratio
         vmax = vcell / parcel%max_vratio
 
-        max_num_parcels = nx * ny * nz * parcel%n_per_cell * parcel%size_factor
+        max_num_parcels = int(nx * ny * nz * parcel%min_vratio * parcel%size_factor)
 
     end subroutine update_parameters
 end module parameters

--- a/src/3d/utils/parameters.f90
+++ b/src/3d/utils/parameters.f90
@@ -57,6 +57,9 @@ module parameters
     ! maximum volume
     double precision :: vmax
 
+    ! maximum number of allowed parcels
+    integer :: max_num_parcels
+
     contains
 
     ! Update all parameters according to the
@@ -102,6 +105,8 @@ module parameters
 
         vmin = vcell / parcel%min_vratio
         vmax = vcell / parcel%max_vratio
+
+        max_num_parcels = nx * ny * nz * parcel%n_per_cell * parcel%size_factor
 
     end subroutine update_parameters
 end module parameters

--- a/src/utils/constants.f90
+++ b/src/utils/constants.f90
@@ -43,7 +43,4 @@ module constants
     double precision, parameter :: rad2deg = 180.0d0 * fpi
     double precision, parameter :: deg2rad = one / rad2deg
 
-    ! maximum number of allowed parcels
-    integer, parameter :: max_num_parcels = 4.5e7
-
 end module


### PR DESCRIPTION
We currently set the maximum number of parcels as a constant `max_num_parcels`. This causes issues when increasing the grid resolution. We should make this a runtime dependent value. I suggest to use `max_num_parcels = nx * ny * nz * n_per_cell * size_factor` (and `nx * nz * n_per_cell * size_factor` in 2D) where `size_factor` is a user-defined input parameter.