### PR TITLE
Change to criterion used in paper

### DIFF
--- a/src/utils/jacobi.f90
+++ b/src/utils/jacobi.f90
@@ -146,7 +146,7 @@ module jacobi
             ! sm should convergence to zero
             sm = dabs(A(1, 2)) + dabs(A(1, 3)) + dabs(A(2, 3))
 
-            do while (sm > atol)
+            do while (sm >= atol)
 
                 do i = 1, n-1
                     do j = i+1, n


### PR DESCRIPTION
In the current version of the 3D paper we write the Jacobi convergence criterion is when the absolute sum of the off-diagonals `sm` is less than `atol`. We need to make the exit statement of the `while` loop to be `sm >= atol` to be consistent.