### PR TITLE
Fix Jacobi solver

### DIFF
--- a/src/utils/jacobi.f90
+++ b/src/utils/jacobi.f90
@@ -26,9 +26,9 @@ module jacobi
             g = hundred * dabs(aij)
             h = D(j) - D(i)
             if (dabs(h) + g == dabs(h)) then
-                t = aij / h
+                t = aij / (h + epsilon(h))
             else
-                theta = f12 * h / aij
+                theta = f12 * h / (aij + epsilon(aij))
                 t = one / (dabs(theta) + dsqrt(one + theta ** 2))
                 if (theta < zero) then
                     t = -t

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -27,6 +27,7 @@ unittests_PROGRAMS = 				\
 	test_jacobi_1				\
 	test_jacobi_2				\
 	test_jacobi_3				\
+	test_jacobi_4				\
 	test_ellipsoid_split 			\
 	test_parcel_init_3d			\
 	test_fft_3d				\
@@ -61,6 +62,9 @@ test_jacobi_2_LDADD = libcombi.la
 
 test_jacobi_3_SOURCES = test_jacobi_3.f90
 test_jacobi_3_LDADD = libcombi.la
+
+test_jacobi_4_SOURCES = test_jacobi_4.f90
+test_jacobi_4_LDADD = libcombi.la
 
 test_ellipsoid_split_SOURCES = test_ellipsoid_split.f90
 test_ellipsoid_split_LDADD = libcombi.la

--- a/unit-tests/3d/test_jacobi_4.f90
+++ b/unit-tests/3d/test_jacobi_4.f90
@@ -1,0 +1,44 @@
+! =============================================================================
+!                       Test Jacobi diagonalisation
+!
+!               This unit test checks the eigenvalue solver for
+!               for a matrix of the form
+!                   /0  0  1\
+!                   |0  0  0|
+!                   \1  0  0/
+!               The eigenvalues of above matrix are +1, 0 and -1 the
+!               corresponding (normalised) eigenvectors:
+!                   v1 = ( 1/sqrt(2),  0,  1/sqrt(2))
+!                   v2 = ( 0,          1,  0)
+!                   v3 = (-1/sqrt(2),  0,  1/sqrt(2))
+! =============================================================================
+program test_jacobi_4
+    use unit_test
+    use constants, only : zero, one, two
+    use jacobi
+    implicit none
+
+    double precision     :: error, V(3, 3), B(3, 3), D(3)
+    double precision, parameter :: fsqrt2 = one / dsqrt(two)
+    error = zero
+
+    B = zero
+    B(1, 3) = one
+    B(3, 1) = one
+
+    call jacobi_diagonalise(B, D, V)
+
+    ! check eigenvalues
+    error = max(error, dabs( one - D(1)) &
+                     + dabs(zero - D(2)) &
+                     + dabs(-one - D(3)))
+
+
+    error = max(error,                                                  &
+                maxval(dabs((/fsqrt2, zero, fsqrt2 /) - V(:, 1))),      &
+                maxval(dabs((/zero,    one,   zero /) - V(:, 2))),      &
+                maxval(dabs((/fsqrt2, zero, -fsqrt2/) - V(:, 3))))
+
+    call print_result_dp('Test Jacobi 4', error, atol=dble(1.0e-15))
+
+end program test_jacobi_4

--- a/unit-tests/netcdf/test_netcdf_dataset_2d.f90
+++ b/unit-tests/netcdf/test_netcdf_dataset_2d.f90
@@ -9,7 +9,7 @@ program test_netcdf_dataset_2d
     implicit none
 
     integer, parameter :: nx = 5, ny = 10
-    integer            :: ix, iy, ncid, dimids(2), map(2)
+    integer            :: ix, iy, ncid, dimids(2)
     integer            :: var_id1 = -1, var_id2 = -1, var_id3 = -1
     double precision   :: dset(ny, nx)
     logical            :: passed = .true.


### PR DESCRIPTION
The Jacobi solver fails for matrices with zeros on the diagonal.