### PR TITLE
Fix MPI reduction

### DIFF
--- a/unit-tests/netcdf/test_mpi_netcdf_dataset_1d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_dataset_1d.f90
@@ -69,9 +69,9 @@ program test_mpi_netcdf_dataset_2d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_dataset_2d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_dataset_2d.f90
@@ -97,9 +97,9 @@ program test_mpi_netcdf_dataset_2d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_dataset_3d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_dataset_3d.f90
@@ -120,9 +120,9 @@ program test_mpi_netcdf_dataset_3d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_read_attributes.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_read_attributes.f90
@@ -186,9 +186,9 @@ program test_mpi_netcdf_read_attributes
     call delete_netcdf_file(ncfname='nctest.nc')
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_read_dataset_1d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_read_dataset_1d.f90
@@ -106,9 +106,9 @@ program test_mpi_netcdf_read_dataset_1d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_read_dataset_2d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_read_dataset_2d.f90
@@ -122,9 +122,9 @@ program test_mpi_netcdf_read_dataset_2d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then

--- a/unit-tests/netcdf/test_mpi_netcdf_read_dataset_3d.f90
+++ b/unit-tests/netcdf/test_mpi_netcdf_read_dataset_3d.f90
@@ -146,9 +146,9 @@ program test_mpi_netcdf_read_dataset_3d
     passed = (passed .and. (ncerr == 0))
 
     if (mpi_rank == mpi_master) then
-        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(MPI_IN_PLACE, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     else
-        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LOR, mpi_master, comm_world, mpi_err)
+        call MPI_Reduce(passed, passed, 1, MPI_LOGICAL, MPI_LAND, mpi_master, comm_world, mpi_err)
     endif
 
     if (mpi_rank == mpi_master) then


### PR DESCRIPTION
We must use `MPI_LAND` and not `MPI_LOR` to check for errors.