### PR TITLE
Flux form including new inversion and net vorticity correction

### DIFF
--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -2,7 +2,7 @@
 !                       EPIC3D - Elliptical Parcel-in-Cell
 ! =============================================================================
 program epic3d
-    use constants, only : zero
+    use constants, only : zero, one
     use timer
     use parcel_container
     use parcel_bc
@@ -131,6 +131,7 @@ program epic3d
 #endif
             double precision :: t = zero    ! current time
             integer          :: cor_iter    ! iterator for parcel correction
+            double precision :: dxi_bar, deta_bar, fvsum
 
             t = time%initial
 
@@ -144,8 +145,15 @@ program epic3d
                 call ls_rk4_step(t)
 
                 !!!
-                parcels%vorticity(1, 1:n_parcels) = parcels%vorticity(1, 1:n_parcels) - xi_bar
-                parcels%vorticity(2, 1:n_parcels) = parcels%vorticity(2, 1:n_parcels) - eta_bar
+                dxi_bar = -xi_bar
+                deta_bar = -eta_bar
+                fvsum = one / sum(parcels%volume(1:n_parcels))
+
+                dxi_bar = dxi_bar + sum(parcels%vorticity(1, 1:n_parcels) * parcels%volume(1:n_parcels))
+                deta_bar = deta_bar + sum(parcels%vorticity(2, 1:n_parcels) * parcels%volume(1:n_parcels))
+
+                parcels%vorticity(1, 1:n_parcels) = parcels%vorticity(1, 1:n_parcels) - dxi_bar
+                parcels%vorticity(2, 1:n_parcels) = parcels%vorticity(2, 1:n_parcels) - deta_bar
                 !!!
 
                 call merge_parcels(parcels)

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -13,7 +13,8 @@ program epic3d
                                   apply_gradient,         &
                                   apply_vortcor,          &
                                   lapl_corr_timer,        &
-                                  grad_corr_timer
+                                  grad_corr_timer,        &
+                                  vort_corr_timer
     use parcel_diagnostics, only : init_parcel_diagnostics, &
                                    parcel_stats_timer
     use parcel_netcdf, only : parcel_io_timer, read_netcdf_parcels
@@ -65,6 +66,7 @@ program epic3d
             call register_timer('parcel merge', merge_timer)
             call register_timer('laplace correction', lapl_corr_timer)
             call register_timer('gradient correction', grad_corr_timer)
+            call register_timer('net vorticity correction', vort_corr_timer)
             call register_timer('parcel initialisation', init_timer)
             call register_timer('parcel diagnostics', parcel_stats_timer)
             call register_timer('parcel I/O', parcel_io_timer)

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -149,8 +149,8 @@ program epic3d
                 deta_bar = -eta_bar
                 fvsum = one / sum(parcels%volume(1:n_parcels))
 
-                dxi_bar = dxi_bar + sum(parcels%vorticity(1, 1:n_parcels) * parcels%volume(1:n_parcels))
-                deta_bar = deta_bar + sum(parcels%vorticity(2, 1:n_parcels) * parcels%volume(1:n_parcels))
+                dxi_bar = dxi_bar + sum(parcels%vorticity(1, 1:n_parcels) * parcels%volume(1:n_parcels)) * fvsum
+                deta_bar = deta_bar + sum(parcels%vorticity(2, 1:n_parcels) * parcels%volume(1:n_parcels)) * fvsum
 
                 parcels%vorticity(1, 1:n_parcels) = parcels%vorticity(1, 1:n_parcels) - dxi_bar
                 parcels%vorticity(2, 1:n_parcels) = parcels%vorticity(2, 1:n_parcels) - deta_bar

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -14,7 +14,8 @@ program epic3d
                                   apply_vortcor,          &
                                   lapl_corr_timer,        &
                                   grad_corr_timer,        &
-                                  vort_corr_timer
+                                  vort_corr_timer,        &
+                                  init_parcel_correction
     use parcel_diagnostics, only : init_parcel_diagnostics, &
                                    parcel_stats_timer
     use parcel_netcdf, only : parcel_io_timer, read_netcdf_parcels

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -14,7 +14,7 @@ program epic3d
                                   lapl_corr_timer,        &
                                   grad_corr_timer
     use parcel_diagnostics, only : init_parcel_diagnostics, &
-                                   parcel_stats_timer
+                                   parcel_stats_timer, xi_bar, eta_bar
     use parcel_netcdf, only : parcel_io_timer, read_netcdf_parcels
     use parcel_diagnostics_netcdf, only : parcel_stats_io_timer
     use fields
@@ -142,6 +142,11 @@ program epic3d
                 endif
 #endif
                 call ls_rk4_step(t)
+
+                !!!
+                parcels%vorticity(1, 1:n_parcels) = parcels%vorticity(1, 1:n_parcels) - xi_bar
+                parcels%vorticity(2, 1:n_parcels) = parcels%vorticity(2, 1:n_parcels) - eta_bar
+                !!!
 
                 call merge_parcels(parcels)
 

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -15,7 +15,7 @@ program epic3d
                                   lapl_corr_timer,        &
                                   grad_corr_timer
     use parcel_diagnostics, only : init_parcel_diagnostics, &
-                                   parcel_stats_timer, xi_bar, eta_bar
+                                   parcel_stats_timer
     use parcel_netcdf, only : parcel_io_timer, read_netcdf_parcels
     use parcel_diagnostics_netcdf, only : parcel_stats_io_timer
     use fields

--- a/src/3d/fields/field_netcdf.f90
+++ b/src/3d/fields/field_netcdf.f90
@@ -20,7 +20,7 @@ module field_netcdf
 
     integer            :: x_vel_id, y_vel_id, z_vel_id, &
                           x_vor_id, y_vor_id, z_vor_id, &
-                          tbuoy_id, n_writes
+                          tbuoy_id, vol_id, n_writes
 #ifndef ENABLE_DRY_MODE
     integer            :: dbuoy_id, lbuoy_id
 #endif
@@ -32,7 +32,7 @@ module field_netcdf
                coord_ids, t_axis_id,            &
                x_vel_id, y_vel_id, z_vel_id,    &
                x_vor_id, y_vor_id, z_vor_id,    &
-               tbuoy_id,                        &
+               tbuoy_id, vol_id,                &
                n_writes, restart_time
 #ifndef ENABLE_DRY_MODE
     private :: dbuoy_id, lbuoy_id
@@ -173,6 +173,16 @@ module field_netcdf
                                        dimids=dimids,                       &
                                        varid=lbuoy_id)
 #endif
+
+            call define_netcdf_dataset(ncid=ncid,                           &
+                                       name='volume',                       &
+                                       long_name='volume',                  &
+                                       std_name='',                         &
+                                       unit='m^3',                          &
+                                       dtype=NF90_DOUBLE,                   &
+                                       dimids=dimids,                       &
+                                       varid=vol_id)
+
             call close_definition(ncid)
 
         end subroutine create_netcdf_field_file
@@ -216,6 +226,7 @@ module field_netcdf
 
             call get_var_id(ncid, 'liquid_water_content', lbuoy_id)
 #endif
+            call get_var_id(ncid, 'volume', vol_id)
         end subroutine read_netcdf_field_content
 
         ! Write a step in the field file.
@@ -273,6 +284,10 @@ module field_netcdf
                                                              - dbuoyg(0:nz, 0:ny-1, 0:nx-1)),   &
                                       start, cnt)
 #endif
+
+            call write_netcdf_dataset(ncid, vol_id, volg(0:nz, 0:ny-1, 0:nx-1), &
+                                      start, cnt)
+
             ! increment counter
             n_writes = n_writes + 1
 

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -201,7 +201,6 @@ module inversion_mod
             double precision, intent(in)  :: tbuoyg(-1:nz+1, 0:ny-1, 0:nx-1)
             double precision, intent(out) :: vtend(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision              :: f(-1:nz+1, 0:ny-1, 0:nx-1, 3)
-            double precision              :: xi_avg, eta_avg
 
             call start_timer(vtend_timer)
 
@@ -223,19 +222,6 @@ module inversion_mod
             f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 3)
 
             call divergence(f, vtend(0:nz, :, :, 3))
-
-            ! Subtract x-y-average
-            xi_avg  = sum(vtend(0, :, :, 1)) / dble(nx * ny)
-            eta_avg = sum(vtend(0, :, :, 2)) / dble(nx * ny)
-
-            vtend(0, :, :, 1) = vtend(0, :, :, 1) - xi_avg
-            vtend(0, :, :, 2) = vtend(0, :, :, 2) - eta_avg
-
-            xi_avg  = sum(vtend(nz, :, :, 1)) / dble(nx * ny)
-            eta_avg = sum(vtend(nz, :, :, 2)) / dble(nx * ny)
-
-            vtend(nz, :, :, 1) = vtend(nz, :, :, 1) - xi_avg
-            vtend(nz, :, :, 2) = vtend(nz, :, :, 2) - eta_avg
 
             ! Extrapolate to halo grid points
             vtend(-1,   :, :, :) = two * vtend(0,  :, :, :) - vtend(1,    :, :, :)

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -134,12 +134,12 @@ module inversion_mod
             ! compute the velocity gradient tensor
             call vel2vgrad(svelog, velgradg)
 
-            ! use symmetry in u and v and anti-symmetry in w to fill z grid points outside domain:
-            velog(-1, :, :, 1)   =  velog(1, :, :, 1) ! u
-            velog(-1, :, :, 2)   =  velog(1, :, :, 2) ! v
-            velog(-1, :, :, 3)   = -velog(1, :, :, 3) ! w
-            velog(nz+1, :, :, 1) =  velog(nz-1, :, :, 1) ! u
-            velog(nz+1, :, :, 2) =  velog(nz-1, :, :, 2) ! v
+            ! use extrapolation in u and v and anti-symmetry in w to fill z grid points outside domain:
+            velog(-1, :, :, 1) =  two * velog(0, :, :, 1) - velog(1, :, :, 1) ! u
+            velog(-1, :, :, 2) =  two * velog(0, :, :, 2) - velog(1, :, :, 2) ! v
+            velog(-1, :, :, 3) = -velog(1, :, :, 3) ! w
+            velog(nz+1, :, :, 1) = two * velog(nz, :, :, 1) - velog(nz-1, :, :, 1) ! u
+            velog(nz+1, :, :, 2) = two * velog(nz, :, :, 2) - velog(nz-1, :, :, 2) ! v
             velog(nz+1, :, :, 3) = -velog(nz-1, :, :, 3) ! w
 
             call stop_timer(vor2vel_timer)

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -195,11 +195,10 @@ module inversion_mod
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Compute the gridded vorticity tendency:
-        subroutine vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
+        subroutine vorticity_tendency(vortg, velog, tbuoyg, vtend)
             double precision, intent(in)  :: vortg(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(in)  :: velog(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(in)  :: tbuoyg(-1:nz+1, 0:ny-1, 0:nx-1)
-            double precision, intent(in)  :: velgradg(-1:nz+1, 0:ny-1, 0:nx-1, 5)
             double precision, intent(out) :: vtend(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision              :: f(-1:nz+1, 0:ny-1, 0:nx-1, 3)
 
@@ -223,25 +222,6 @@ module inversion_mod
             f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 3)
 
             call divergence(f, vtend(0:nz, :, :, 3))
-
-            ! Fill boundary values:
-            ! \omegax * du/dx + \omegay * dv/dx (where dv/dx = \omegaz + du/dy)
-            vtend(0, :, :, 1) = vortg(0, :, :, 1) * velgradg(0, :, :, 1) &
-                              + vortg(0, :, :, 2) * (vortg(0, :, :, 3 ) + velgradg(0, :, :, 2))
-
-            vtend(nz, :, :, 1) = vortg(nz, :, :, 1) * velgradg(nz, :, :, 1) &
-                               + vortg(nz, :, :, 2) * (vortg(nz, :, :, 3 ) + velgradg(nz, :, :, 2))
-
-            ! \omegax * du/dy + \omegay * dv/dy
-            vtend(0, :, :, 2) = vortg(0, :, :, 1) * velgradg(0, :, :, 2) &
-                              + vortg(0, :, :, 2) * velgradg(0, :, :, 3)
-
-            vtend(nz, :, :, 2) = vortg(nz, :, :, 1) * velgradg(nz, :, :, 2) &
-                               + vortg(nz, :, :, 2) * velgradg(nz, :, :, 3)
-
-            ! - \omegaz * (du/dx + dv/dy)
-            vtend(0,  :, :, 3) = - vortg(0,  :, :, 3) * (velgradg(0,  :, :, 1) + velgradg(0,  :, :, 3))
-            vtend(nz, :, :, 3) = - vortg(nz, :, :, 3) * (velgradg(nz, :, :, 1) + velgradg(nz, :, :, 3))
 
             ! Extrapolate to halo grid points
             vtend(-1,   :, :, :) = two * vtend(0,  :, :, :) - vtend(1,    :, :, :)

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -1,7 +1,7 @@
 module inversion_mod
     use inversion_utils
     use parameters, only : nx, ny, nz, dxi
-    use physics, only : ft_cor, f_cor
+    use physics, only : f_cor
     use constants, only : zero, two, f12
     use timer, only : start_timer, stop_timer
     implicit none
@@ -205,21 +205,21 @@ module inversion_mod
             call start_timer(vtend_timer)
 
             ! Eqs. 10 and 11 of MPIC paper
-            f(:, : , :, 1) = vortg(:, :, :, 1) * velog(:, :, :, 1)
-            f(:, : , :, 2) = vortg(:, :, :, 2) * velog(:, :, :, 1) + tbuoyg
-            f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 1)
+            f(:, : , :, 1) = (vortg(:, :, :, 1) + f_cor(1)) * velog(:, :, :, 1)
+            f(:, : , :, 2) = (vortg(:, :, :, 2) + f_cor(2)) * velog(:, :, :, 1) + tbuoyg
+            f(:, : , :, 3) = (vortg(:, :, :, 3) + f_cor(3)) * velog(:, :, :, 1)
 
             call divergence(f, vtend(0:nz, :, :, 1))
 
-            f(:, : , :, 1) = vortg(:, :, :, 1) * velog(:, :, :, 2) - tbuoyg
-            f(:, : , :, 2) = vortg(:, :, :, 2) * velog(:, :, :, 2)
-            f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 2)
+            f(:, : , :, 1) = (vortg(:, :, :, 1) + f_cor(1)) * velog(:, :, :, 2) - tbuoyg
+            f(:, : , :, 2) = (vortg(:, :, :, 2) + f_cor(2)) * velog(:, :, :, 2)
+            f(:, : , :, 3) = (vortg(:, :, :, 3) + f_cor(3)) * velog(:, :, :, 2)
 
             call divergence(f, vtend(0:nz, :, :, 2))
 
-            f(:, : , :, 1) = vortg(:, :, :, 1) * velog(:, :, :, 3)
-            f(:, : , :, 2) = vortg(:, :, :, 2) * velog(:, :, :, 3)
-            f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 3)
+            f(:, : , :, 1) = (vortg(:, :, :, 1) + f_cor(1)) * velog(:, :, :, 3)
+            f(:, : , :, 2) = (vortg(:, :, :, 2) + f_cor(2)) * velog(:, :, :, 3)
+            f(:, : , :, 3) = (vortg(:, :, :, 3) + f_cor(3)) * velog(:, :, :, 3)
 
             call divergence(f, vtend(0:nz, :, :, 3))
 

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -18,7 +18,7 @@ module inversion_mod
         ! gradient tensor (velgradg).  Note: the
         ! vorticity is modified to be solenoidal and spectrally filtered.
         subroutine vor2vel(vortg,  velog,  velgradg)
-            double precision, intent(inout) :: vortg(-1:nz+1, 0:ny-1, 0:nx-1, 3)
+            double precision, intent(in)    :: vortg(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(out)   :: velog(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(out)   :: velgradg(-1:nz+1, 0:ny-1, 0:nx-1, 5)
             double precision                :: svelog(0:nz, 0:nx-1, 0:ny-1, 3)
@@ -26,93 +26,42 @@ module inversion_mod
                                              , bs(0:nz, 0:nx-1, 0:ny-1) &
                                              , cs(0:nz, 0:nx-1, 0:ny-1)
             double precision                :: ds(0:nz, 0:nx-1, 0:ny-1) &
-                                             , es(0:nz, 0:nx-1, 0:ny-1) &
-                                             , fs(0:nz, 0:nx-1, 0:ny-1)
+                                             , es(0:nz, 0:nx-1, 0:ny-1)
             double precision                :: ubar(0:nz), vbar(0:nz)
             double precision                :: uavg, vavg
             integer                         :: iz
 
             call start_timer(vor2vel_timer)
 
+            ! Copy vorticity to velocity field to perform FFT transforms
+            ! (FFT transforms overwrite the input array)
+            velog = vortg
+
             !------------------------------------------------------------------
-            !Convert vorticity to spectral space as (as, bs, cs):
-            call fftxyp2s(vortg(0:nz, :, :, 1), as)
-            call fftxyp2s(vortg(0:nz, :, :, 2), bs)
-            call fftxyp2s(vortg(0:nz, :, :, 3), cs)
+            !Convert vorticity to semi-spectral space as (as, bs, cs): (velog is overwritten in this operation)
+            call fftxyp2s(velog(0:nz, :, :, 1), as)
+            call fftxyp2s(velog(0:nz, :, :, 2), bs)
+            call fftxyp2s(velog(0:nz, :, :, 3), cs)
 
-            !Add -grad(lambda) where Laplace(lambda) = div(vortg) to
-            !enforce the solenoidal condition on the vorticity field:
-            call diffx(as, ds)
-            call diffy(bs, es)
-
-            !For the vertical parcel vorticity, use 2nd-order
-            !differencing:
-            call diffz(cs, fs)
-
-            !Form div(vortg):
-            !$omp parallel
-            !$omp workshare
-            fs = ds + es + fs
-            !$omp end workshare
-            !$omp end parallel
-
-            !Remove horizontally-averaged part (plays no role):
-            fs(:, 0, 0) = zero
-
-            !Invert Lap(lambda) = div(vortg) assuming dlambda/dz = 0 at the
-            !boundaries (store solution lambda in fs):
-            call lapinv1(fs)
-
-            !Filter lambda:
-            !$omp parallel shared(fs, filt, nz) private(iz)  default(none)
+            !-------------------------------------------------------------
+            ! Apply 2D Hou and Li filter:
+            !$omp parallel shared(as, bs, cs, filt, nz) private(iz) default(none)
             !$omp do
             do iz = 0, nz
-                fs(iz, :, :) = filt * fs(iz, :, :)
+                as(iz, :, :) = filt * as(iz, :, :)
+                bs(iz, :, :) = filt * bs(iz, :, :)
+                cs(iz, :, :) = filt * cs(iz, :, :)
             enddo
             !$omp end do
             !$omp end parallel
 
-            !Subtract grad(lambda) to enforce div(vortg) = 0:
-            call diffx(fs, ds)
-            !$omp parallel
-            !$omp workshare
-            as = as - ds
-            !$omp end workshare
-            !$omp end parallel
-
-            call diffy(fs, ds)
-            !$omp parallel
-            !$omp workshare
-            bs = bs - ds
-            !$omp end workshare
-            !$omp end parallel
-
-            call diffz(fs, ds)
-            !$omp parallel
-            !$omp workshare
-            cs = cs - ds
-            !$omp end workshare
-            !$omp end parallel
-            !Ensure horizontal average of vertical vorticity is zero:
-            cs(:, 0, 0) = zero
-
-            !Compute spectrally filtered vorticity in physical space:
-            !$omp parallel shared(ds, es, fs, as, bs, cs, filt, nz) private(iz) default(none)
-            !$omp do
-            do iz = 0, nz
-                ds(iz, :, :) = filt * as(iz, :, :)
-                es(iz, :, :) = filt * bs(iz, :, :)
-                fs(iz, :, :) = filt * cs(iz, :, :)
-            enddo
-            !$omp end do
-            !$omp end parallel
 
             !Define horizontally-averaged flow by integrating horizontal vorticity:
             ubar(0) = zero
             vbar(0) = zero
             do iz = 0, nz-1
-                ubar(iz+1) = ubar(iz) + dz2 * (es(iz, 0, 0) + es(iz+1, 0, 0))
-                vbar(iz+1) = vbar(iz) - dz2 * (ds(iz, 0, 0) + ds(iz+1, 0, 0))
+                ubar(iz+1) = ubar(iz) + dz2 * (bs(iz, 0, 0) + bs(iz+1, 0, 0))
+                vbar(iz+1) = vbar(iz) - dz2 * (as(iz, 0, 0) + as(iz+1, 0, 0))
             enddo
 
             ! remove the mean value to have zero net momentum
@@ -123,86 +72,67 @@ module inversion_mod
                 vbar(iz) = vbar(iz) - vavg
             enddo
 
-            !Return corrected vorticity to physical space:
-            call fftxys2p(ds, vortg(0:nz, :, :, 1))
-            call fftxys2p(es, vortg(0:nz, :, :, 2))
-            call fftxys2p(fs, vortg(0:nz, :, :, 3))
-
-            !-----------------------------------------------------------------
-            !Invert vorticity to find vector potential (A, B, C) -> (as, bs, cs):
-            call lapinv0(as)
-            call lapinv0(bs)
-            call lapinv1(cs)
-
-            !------------------------------------------------------------
-            !Compute x velocity component, u = B_z - C_y:
-            call diffy(cs, ds)
-            call diffz(bs, es)
+            !Form source term for inversion of vertical velocity:
+            call diffy(as, ds)
+            call diffx(bs, es)
 
             !$omp parallel
             !$omp workshare
-            fs = es - ds
+            ds = ds - es
             !$omp end workshare
             !$omp end parallel
+
+            !as & bs are now free to re-use
+
+            !Invert to find vertical velocity \hat{w} (store in ds, spectrally):
+            call lapinv0(ds)
+
+            !Find \hat{w}' (store in es, spectrally):
+            call diffz(ds, es)
+
+            !Find x velocity component \hat{u}:
+            call diffx(es, as)
+            call diffy(cs, bs)
+
+            !$omp parallel do
+            do iz = 0, nz
+                as(iz, :, :) = k2l2i * (as(iz, :, :) + bs(iz, :, :))
+            enddo
+            !$omp end parallel do
+
             !Add horizontally-averaged flow:
-            fs(:, 0, 0) = ubar
-            !$omp parallel shared(svelog, fs, filt, nz) private(iz) default(none)
-            !$omp do
+            as(:, 0, 0) = ubar
+
+            svelog(:, :, :, 1) = as
+
+            !Get u in physical space:
+            call fftxys2p(as, velog(0:nz, :, :, 1))
+
+            !Find y velocity component \hat{v}:
+            call diffy(es, as)
+            call diffx(cs, bs)
+
+            !$omp parallel do
             do iz = 0, nz
-                svelog(iz, :, :, 1) = filt * fs(iz, :, :)
+                as(iz, :, :) = k2l2i * (as(iz, :, :) - bs(iz, :, :))
             enddo
-            !$omp end do
-            !$omp end parallel
+            !$omp end parallel do
 
-            !------------------------------------------------------------
-            !Compute y velocity component, v = C_x - A_z:
-            call diffx(cs, ds)
-            call diffz(as, es)
-
-            !$omp parallel
-            !$omp workshare
-            fs = ds - es
-            !$omp end workshare
-            !$omp end parallel
             !Add horizontally-averaged flow:
-            fs(:, 0, 0) = vbar
-            !$omp parallel shared(svelog, fs, filt, nz) private(iz) default(none)
-            !$omp do
-            do iz = 0, nz
-                svelog(iz, :, :, 2) = filt * fs(iz, :, :)
-            enddo
-            !$omp end do
-            !$omp end parallel
+            as(:, 0, 0) = vbar
 
-            !------------------------------------------------------------
-            !Compute z velocity component, w = A_y - B_x:
-            call diffx(bs, ds)
-            call diffy(as, es)
-            !$omp parallel
-            !$omp workshare
-            fs = es - ds
-            !$omp end workshare
-            !$omp end parallel
+            svelog(:, :, :, 2) = as
 
-            !$omp parallel shared(svelog, fs, filt, nz) private(iz) default(none)
-            !$omp do
-            do iz = 0, nz
-                svelog(iz, :, :, 3) = filt * fs(iz, :, :)
-            enddo
-            !$omp end do
-            !$omp end parallel
+            !Get v in physical space:
+            call fftxys2p(as, velog(0:nz, :, :, 2))
+
+            svelog(:, :, :, 3) = ds
+
+            !Get w in physical space:
+            call fftxys2p(ds, velog(0:nz, :, :, 3))
 
             ! compute the velocity gradient tensor
             call vel2vgrad(svelog, velgradg)
-
-            !Get u in physical space:
-            call fftxys2p(svelog(0:nz, :, :, 1), velog(0:nz, :, :, 1))
-
-            !Get v in physical space:
-            call fftxys2p(svelog(0:nz, :, :, 2), velog(0:nz, :, :, 2))
-
-            !Get w in physical space:
-            call fftxys2p(svelog(0:nz, :, :, 3), velog(0:nz, :, :, 3))
 
             ! use extrapolation in u and v and anti-symmetry in w to fill z grid points outside domain:
             velog(-1, :, :, 1) =  two * velog(0, :, :, 1) - velog(1, :, :, 1) ! u

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -195,10 +195,11 @@ module inversion_mod
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         ! Compute the gridded vorticity tendency:
-        subroutine vorticity_tendency(vortg, velog, tbuoyg, vtend)
+        subroutine vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
             double precision, intent(in)  :: vortg(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(in)  :: velog(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision, intent(in)  :: tbuoyg(-1:nz+1, 0:ny-1, 0:nx-1)
+            double precision, intent(in)  :: velgradg(-1:nz+1, 0:ny-1, 0:nx-1, 5)
             double precision, intent(out) :: vtend(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision              :: f(-1:nz+1, 0:ny-1, 0:nx-1, 3)
 
@@ -222,6 +223,25 @@ module inversion_mod
             f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 3)
 
             call divergence(f, vtend(0:nz, :, :, 3))
+
+            ! Fill boundary values:
+            ! \omegax * du/dx + \omegay * dv/dx (where dv/dx = \omegaz + du/dy)
+            vtend(0, :, :, 1) = vortg(0, :, :, 1) * velgradg(0, :, :, 1) &
+                              + vortg(0, :, :, 2) * (vortg(0, :, :, 3 ) + velgradg(0, :, :, 2))
+
+            vtend(nz, :, :, 1) = vortg(nz, :, :, 1) * velgradg(nz, :, :, 1) &
+                               + vortg(nz, :, :, 2) * (vortg(nz, :, :, 3 ) + velgradg(nz, :, :, 2))
+
+            ! \omegax * du/dy + \omegay * dv/dy
+            vtend(0, :, :, 2) = vortg(0, :, :, 1) * velgradg(0, :, :, 2) &
+                              + vortg(0, :, :, 2) * velgradg(0, :, :, 3)
+
+            vtend(nz, :, :, 2) = vortg(nz, :, :, 1) * velgradg(nz, :, :, 2) &
+                               + vortg(nz, :, :, 2) * velgradg(nz, :, :, 3)
+
+            ! - \omegaz * (du/dx + dv/dy)
+            vtend(0,  :, :, 3) = - vortg(0,  :, :, 3) * (velgradg(0,  :, :, 1) + velgradg(0,  :, :, 3))
+            vtend(nz, :, :, 3) = - vortg(nz, :, :, 3) * (velgradg(nz, :, :, 1) + velgradg(nz, :, :, 3))
 
             ! Extrapolate to halo grid points
             vtend(-1,   :, :, :) = two * vtend(0,  :, :, :) - vtend(1,    :, :, :)

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -254,11 +254,9 @@ module inversion_mod
             div = div + df
 
             ! calculate df/dz with central differencing
-            do i = 1, nz-1
+            do i = 0, nz
                 df(i, 0:ny-1, 0:nx-1) = f12 * dxi(3) * (f(i+1, 0:ny-1, 0:nx-1, 3) - f(i-1, 0:ny-1, 0:nx-1, 3))
             enddo
-            df(0,  0:ny-1, 0:nx-1) = f12 * dxi(3) * (f(1,    0:ny-1, 0:nx-1, 3) - f(-1,   0:ny-1, 0:nx-1, 3))
-            df(nz, 0:ny-1, 0:nx-1) = f12 * dxi(3) * (f(nz+1, 0:ny-1, 0:nx-1, 3) - f(nz-1, 0:ny-1, 0:nx-1, 3))
 
             div = div + df
 

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -134,12 +134,12 @@ module inversion_mod
             ! compute the velocity gradient tensor
             call vel2vgrad(svelog, velgradg)
 
-            ! use extrapolation in u and v and anti-symmetry in w to fill z grid points outside domain:
-            velog(-1, :, :, 1) =  two * velog(0, :, :, 1) - velog(1, :, :, 1) ! u
-            velog(-1, :, :, 2) =  two * velog(0, :, :, 2) - velog(1, :, :, 2) ! v
-            velog(-1, :, :, 3) = -velog(1, :, :, 3) ! w
-            velog(nz+1, :, :, 1) = two * velog(nz, :, :, 1) - velog(nz-1, :, :, 1) ! u
-            velog(nz+1, :, :, 2) = two * velog(nz, :, :, 2) - velog(nz-1, :, :, 2) ! v
+            ! use symmetry in u and v and anti-symmetry in w to fill z grid points outside domain:
+            velog(-1, :, :, 1)   =  velog(1, :, :, 1) ! u
+            velog(-1, :, :, 2)   =  velog(1, :, :, 2) ! v
+            velog(-1, :, :, 3)   = -velog(1, :, :, 3) ! w
+            velog(nz+1, :, :, 1) =  velog(nz-1, :, :, 1) ! u
+            velog(nz+1, :, :, 2) =  velog(nz-1, :, :, 2) ! v
             velog(nz+1, :, :, 3) = -velog(nz-1, :, :, 3) ! w
 
             call stop_timer(vor2vel_timer)

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -201,6 +201,7 @@ module inversion_mod
             double precision, intent(in)  :: tbuoyg(-1:nz+1, 0:ny-1, 0:nx-1)
             double precision, intent(out) :: vtend(-1:nz+1, 0:ny-1, 0:nx-1, 3)
             double precision              :: f(-1:nz+1, 0:ny-1, 0:nx-1, 3)
+            double precision              :: xi_avg, eta_avg
 
             call start_timer(vtend_timer)
 
@@ -222,6 +223,19 @@ module inversion_mod
             f(:, : , :, 3) = vortg(:, :, :, 3) * velog(:, :, :, 3)
 
             call divergence(f, vtend(0:nz, :, :, 3))
+
+            ! Subtract x-y-average
+            xi_avg  = sum(vtend(0, :, :, 1)) / dble(nx * ny)
+            eta_avg = sum(vtend(0, :, :, 2)) / dble(nx * ny)
+
+            vtend(0, :, :, 1) = vtend(0, :, :, 1) - xi_avg
+            vtend(0, :, :, 2) = vtend(0, :, :, 2) - eta_avg
+
+            xi_avg  = sum(vtend(nz, :, :, 1)) / dble(nx * ny)
+            eta_avg = sum(vtend(nz, :, :, 2)) / dble(nx * ny)
+
+            vtend(nz, :, :, 1) = vtend(nz, :, :, 1) - xi_avg
+            vtend(nz, :, :, 2) = vtend(nz, :, :, 2) - eta_avg
 
             ! Extrapolate to halo grid points
             vtend(-1,   :, :, :) = two * vtend(0,  :, :, :) - vtend(1,    :, :, :)

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -19,6 +19,9 @@ module inversion_utils
     !Horizontal wavenumbers:
     double precision, allocatable :: rkx(:), hrkx(:), rky(:), hrky(:)
 
+    ! Note k2l2i = 1/(k^2+l^2) (except k = l = 0, then k2l2i(0, 0) = 0)
+    double precision, allocatable :: k2l2i(:, :)
+
     !Quantities needed in FFTs:
     double precision, allocatable :: xtrig(:), ytrig(:)
     integer :: xfactors(5), yfactors(5)
@@ -51,7 +54,8 @@ module inversion_utils
             , xfactors  &
             , yfactors  &
             , xtrig     &
-            , ytrig
+            , ytrig     &
+            , k2l2i
 
     contains
 
@@ -88,6 +92,7 @@ module inversion_utils
             allocate(ksq(nx, ny))
             allocate(skx(nx))
             allocate(sky(ny))
+            allocate(k2l2i(nx, ny))
 
             allocate(etdh(nz-1, nx, ny))
             allocate(htdh(nz-1, nx, ny))
@@ -134,6 +139,10 @@ module inversion_utils
                     ksq(kx, ky) = rkx(kx) ** 2 + rky(ky) ** 2
                 enddo
             enddo
+
+            ksq(1, 1) = one
+            k2l2i = one / ksq
+            ksq(1, 1) = zero
 
             !--------------------------------------------------------------------
             ! Define Hou and Li filter:

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -17,16 +17,19 @@ module parcel_correction
     private
 
     integer :: lapl_corr_timer, &
-               grad_corr_timer
+               grad_corr_timer, &
+               vort_corr_timer
 
     ! initial volume-weighted vorticity mean
-    double precision :: vor_bar
+    double precision :: vor_bar(3)
 
     public :: init_parcel_correction, &
               apply_laplace,          &
               apply_gradient,         &
+              apply_vortcor,          &
               lapl_corr_timer,        &
-              grad_corr_timer
+              grad_corr_timer,        &
+              vort_corr_timer
 
     contains
 
@@ -34,6 +37,8 @@ module parcel_correction
         subroutine init_parcel_correction
             integer          :: n
             double precision :: vsum
+
+            call start_timer(vort_corr_timer)
 
             vsum = zero
 
@@ -48,6 +53,8 @@ module parcel_correction
 
             vor_bar = vor_bar / vsum
 
+            call stop_timer(vort_corr_timer)
+
         end subroutine init_parcel_correction
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -57,6 +64,8 @@ module parcel_correction
         subroutine apply_vortcor
             integer          :: n
             double precision :: dvor(3), vsum
+
+            call start_timer(vort_corr_timer)
 
             vsum = zero
             dvor = - vor_bar
@@ -79,6 +88,8 @@ module parcel_correction
             enddo
             !$omp end do
             !$omp end parallel
+
+            call stop_timer(vort_corr_timer)
         end subroutine apply_vortcor
 
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -115,12 +115,13 @@ module parcel_correction
 
             call diverge(phi, ud(0:nz, :, :), vd(0:nz, :, :), wd(0:nz, :, :))
 
-            ! use symmetry to fill z grid lines outside domain:
-            ud(-1, :, :)   =  ud(1, :, :)
-            vd(-1, :, :)   =  vd(1, :, :)
+            ! use extrapolation to fill z grid lines outside domain:
+            ! (anti-symmetry in w is equal to extrapolation)
+            ud(-1, :, :)   =  two * ud(0, :, :) - ud(1, :, :)
+            vd(-1, :, :)   =  two * vd(0, :, :) - vd(1, :, :)
             wd(-1, :, :)   = -wd(1, :, :)
-            ud(nz+1, :, :) =  ud(nz-1, :, :)
-            vd(nz+1, :, :) =  vd(nz-1, :, :)
+            ud(nz+1, :, :) =  two * ud(nz, :, :) - ud(nz-1, :, :)
+            vd(nz+1, :, :) =  two * vd(nz, :, :) - vd(nz-1, :, :)
             wd(nz+1, :, :) = -wd(nz-1, :, :)
 
             !------------------------------------------------------------------

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -40,6 +40,8 @@ module parcel_correction
 
             call start_timer(vort_corr_timer)
 
+            call init_fft
+
             vsum = zero
             vor_bar = zero
 

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -14,8 +14,13 @@ module parcel_correction
     use fields, only : volg
     implicit none
 
+    private
+
     integer :: lapl_corr_timer, &
                grad_corr_timer
+
+    ! initial volume-weighted vorticity mean
+    double precision :: vor_bar
 
     public :: init_parcel_correction, &
               apply_laplace,          &
@@ -23,149 +28,194 @@ module parcel_correction
               lapl_corr_timer,        &
               grad_corr_timer
 
-
     contains
 
         ! Initialise parcel correction module
         subroutine init_parcel_correction
-            call init_fft
+            integer          :: n
+            double precision :: vsum
+
+            vsum = zero
+
+            !$omp parallel default(shared)
+            !$omp do private(n) reduction(+: vor_bar, vsum)
+            do n = 1, n_parcels
+                vsum = vsum + parcels%volume(n)
+                vor_bar = vor_bar + parcels%vorticity(:, n) * parcels%volume(n)
+            enddo
+            !$omp end do
+            !$omp end parallel
+
+            vor_bar = vor_bar / vsum
+
         end subroutine init_parcel_correction
 
-    !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-    subroutine apply_laplace(l_reuse)
-        logical, optional, intent(in) :: l_reuse
-        double precision              :: phi(0:nz, 0:ny-1, 0:nx-1),   &
-                                         ud(-1:nz+1, 0:ny-1, 0:nx-1), &
-                                         vd(-1:nz+1, 0:ny-1, 0:nx-1), &
-                                         wd(-1:nz+1, 0:ny-1, 0:nx-1)
-        double precision              :: weights(ngp)
-        integer                       :: n, l, is(ngp), js(ngp), ks(ngp)
+        ! This subroutine makes sure that the net vorticity
+        ! (volume-integrated vorticity) remains constant.
+        subroutine apply_vortcor
+            integer          :: n
+            double precision :: dvor(3), vsum
 
-        call start_timer(lapl_corr_timer)
+            vsum = zero
+            dvor = - vor_bar
 
-        call vol2grid(l_reuse)
-
-        ! form divergence field
-        phi = volg(0:nz, :, :) * vcelli - one
-
-        call diverge(phi, ud(0:nz, :, :), vd(0:nz, :, :), wd(0:nz, :, :))
-
-        ! use symmetry to fill z grid lines outside domain:
-        ud(-1, :, :)   =  ud(1, :, :)
-        vd(-1, :, :)   =  vd(1, :, :)
-        wd(-1, :, :)   = -wd(1, :, :)
-        ud(nz+1, :, :) =  ud(nz-1, :, :)
-        vd(nz+1, :, :) =  vd(nz-1, :, :)
-        wd(nz+1, :, :) = -wd(nz-1, :, :)
-
-        !------------------------------------------------------------------
-        ! Increment parcel positions usind (ud, vd, wd) field:
-        !$omp parallel default(shared)
-        !$omp do private(n, l, is, js, ks, weights)
-        do n = 1, n_parcels
-            call trilinear(parcels%position(:, n), is, js, ks, weights)
-
-            do l = 1, ngp
-                parcels%position(1, n) = parcels%position(1, n)               &
-                                       + weights(l) * ud(ks(l), js(l), is(l))
-
-                parcels%position(2, n) = parcels%position(2, n)               &
-                                       + weights(l) * vd(ks(l), js(l), is(l))
-
-                parcels%position(3, n) = parcels%position(3, n)               &
-                                       + weights(l) * wd(ks(l), js(l), is(l))
+            !$omp parallel default(shared)
+            !$omp do private(n) reduction(+: dvor, vsum)
+            do n = 1, n_parcels
+                vsum = vsum + parcels%volume(n)
+                dvor = dvor + parcels%vorticity(:, n) * parcels%volume(n)
             enddo
+            !$omp end do
+            !$omp end parallel
 
-            call apply_periodic_bc(parcels%position(:, n))
-        enddo
-        !$omp end do
-        !$omp end parallel
+            dvor = dvor / vsum
 
-        call stop_timer(lapl_corr_timer)
+            !$omp parallel default(shared)
+            !$omp do private(n)
+            do n = 1, n_parcels
+                parcels%vorticity(:, n) = parcels%vorticity(:, n) - dvor
+            enddo
+            !$omp end do
+            !$omp end parallel
+        end subroutine apply_vortcor
 
-    end subroutine apply_laplace
+        !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-    subroutine apply_gradient(prefactor, max_compression, l_reuse)
-        double precision,  intent(in) :: prefactor
-        double precision,  intent(in) :: max_compression
-        logical, optional, intent(in) :: l_reuse
-        double precision              :: phi(0:nz, 0:ny-1, 0:nx-1)
-        double precision              :: weights(ngp)
-        double precision              :: xs, ys, zs, xf, yf, zf, lim_x, lim_y, lim_z
-        integer                       :: n, is(ngp), js(ngp), ks(ngp)
+        subroutine apply_laplace(l_reuse)
+            logical, optional, intent(in) :: l_reuse
+            double precision              :: phi(0:nz, 0:ny-1, 0:nx-1),   &
+                                            ud(-1:nz+1, 0:ny-1, 0:nx-1), &
+                                            vd(-1:nz+1, 0:ny-1, 0:nx-1), &
+                                            wd(-1:nz+1, 0:ny-1, 0:nx-1)
+            double precision              :: weights(ngp)
+            integer                       :: n, l, is(ngp), js(ngp), ks(ngp)
 
-        call start_timer(grad_corr_timer)
+            call start_timer(lapl_corr_timer)
 
-        call vol2grid(l_reuse)
+            call vol2grid(l_reuse)
 
-        ! form divergence field * dt and store in phi temporarily:
-        phi = volg(0:nz, :, :) * vcelli - one
+            ! form divergence field
+            phi = volg(0:nz, :, :) * vcelli - one
 
-        !$omp parallel default(shared)
-        !$omp do private(n, is, js, ks, weights, xf, yf, zf, xs, ys, zs, lim_x, lim_y, lim_z)
-        do n = 1, n_parcels
+            call diverge(phi, ud(0:nz, :, :), vd(0:nz, :, :), wd(0:nz, :, :))
 
-            call trilinear(parcels%position(:, n), is, js, ks, weights)
+            ! use symmetry to fill z grid lines outside domain:
+            ud(-1, :, :)   =  ud(1, :, :)
+            vd(-1, :, :)   =  vd(1, :, :)
+            wd(-1, :, :)   = -wd(1, :, :)
+            ud(nz+1, :, :) =  ud(nz-1, :, :)
+            vd(nz+1, :, :) =  vd(nz-1, :, :)
+            wd(nz+1, :, :) = -wd(nz-1, :, :)
 
-            xf = weights(2) + weights(4) + weights(6) + weights(8) ! fractional position along x
-            yf = weights(3) + weights(4) + weights(7) + weights(8) ! fractional position along y
-            zf = weights(5) + weights(6) + weights(7) + weights(8) ! fractional position along z
+            !------------------------------------------------------------------
+            ! Increment parcel positions usind (ud, vd, wd) field:
+            !$omp parallel default(shared)
+            !$omp do private(n, l, is, js, ks, weights)
+            do n = 1, n_parcels
+                call trilinear(parcels%position(:, n), is, js, ks, weights)
 
-            ! l   ks(l) js(l) is(l)
-            ! 1   k     j     i
-            ! 2   k     j     i+1
-            ! 3   k     j+1   i
-            ! 4   k     j+1   i+1
-            ! 5   k+1   j     i
-            ! 6   k+1   j     i+1
-            ! 7   k+1   j+1   i
-            ! 8   k+1   j+1   i+1
-            lim_x = dx(1) * xf * (one - xf)
-            xs = - prefactor * lim_x * (&
-                        (one - zf) * (&
-                                (one - yf) * (phi(ks(2), js(2), is(2)) - phi(ks(1), js(1), is(1)))  &
-                              +       (yf) * (phi(ks(4), js(4), is(4)) - phi(ks(3), js(3), is(3)))) &
-                       +      (zf) * (&
-                                (one - yf) * (phi(ks(6), js(6), is(6)) - phi(ks(5), js(5), is(5)))  &
-                              +       (yf) * (phi(ks(8), js(8), is(8)) - phi(ks(7), js(7), is(7)))))
+                do l = 1, ngp
+                    parcels%position(1, n) = parcels%position(1, n)               &
+                                           + weights(l) * ud(ks(l), js(l), is(l))
 
-            lim_x = lim_x * max_compression
-            xs = max(-lim_x, min(xs, lim_x))
+                    parcels%position(2, n) = parcels%position(2, n)               &
+                                           + weights(l) * vd(ks(l), js(l), is(l))
 
-            lim_y = dx(2) * yf * (one - yf)
-            ys = - prefactor * lim_y * (&
-                        (one - zf) * (&
-                                (one - xf) * (phi(ks(3), js(3), is(3)) - phi(ks(1), js(1), is(1)))  &
-                              +       (xf) * (phi(ks(4), js(4), is(4)) - phi(ks(2), js(2), is(2)))) &
-                       +      (zf) * (&
-                                (one - xf) * (phi(ks(7), js(7), is(7)) - phi(ks(5), js(5), is(5)))  &
-                              +       (xf) * (phi(ks(8), js(8), is(8)) - phi(ks(6), js(6), is(6)))))
+                    parcels%position(3, n) = parcels%position(3, n)               &
+                                           + weights(l) * wd(ks(l), js(l), is(l))
+                enddo
 
-            lim_y = lim_y * max_compression
-            ys = max(-lim_y, min(ys, lim_y))
+                call apply_periodic_bc(parcels%position(:, n))
+            enddo
+            !$omp end do
+            !$omp end parallel
 
-            lim_z = dx(3) * zf * (one - zf)
-            zs = - prefactor * lim_z * (&
-                        (one - xf) * (&
-                                (one - yf) * (phi(ks(5), js(5), is(5)) - phi(ks(1), js(1), is(1)))  &
-                              +       (yf) * (phi(ks(7), js(7), is(7)) - phi(ks(3), js(3), is(3)))) &
-                       +      (xf) * (&
-                                (one - yf) * (phi(ks(6), js(6), is(6)) - phi(ks(2), js(2), is(2)))  &
-                              +       (yf) * (phi(ks(8), js(8), is(8)) - phi(ks(4), js(4), is(4)))))
+            call stop_timer(lapl_corr_timer)
 
-            lim_z = lim_z * max_compression
-            zs = max(-lim_z, min(zs, lim_z))
+        end subroutine apply_laplace
 
-            parcels%position(1, n) = parcels%position(1, n) + xs
-            parcels%position(2, n) = parcels%position(2, n) + ys
-            parcels%position(3, n) = parcels%position(3, n) + zs
-        enddo
-        !$omp end do
-        !$omp end parallel
+        subroutine apply_gradient(prefactor, max_compression, l_reuse)
+            double precision,  intent(in) :: prefactor
+            double precision,  intent(in) :: max_compression
+            logical, optional, intent(in) :: l_reuse
+            double precision              :: phi(0:nz, 0:ny-1, 0:nx-1)
+            double precision              :: weights(ngp)
+            double precision              :: xs, ys, zs, xf, yf, zf, lim_x, lim_y, lim_z
+            integer                       :: n, is(ngp), js(ngp), ks(ngp)
 
-        call stop_timer(grad_corr_timer)
+            call start_timer(grad_corr_timer)
 
-    end subroutine apply_gradient
+            call vol2grid(l_reuse)
+
+            ! form divergence field * dt and store in phi temporarily:
+            phi = volg(0:nz, :, :) * vcelli - one
+
+            !$omp parallel default(shared)
+            !$omp do private(n, is, js, ks, weights, xf, yf, zf, xs, ys, zs, lim_x, lim_y, lim_z)
+            do n = 1, n_parcels
+
+                call trilinear(parcels%position(:, n), is, js, ks, weights)
+
+                xf = weights(2) + weights(4) + weights(6) + weights(8) ! fractional position along x
+                yf = weights(3) + weights(4) + weights(7) + weights(8) ! fractional position along y
+                zf = weights(5) + weights(6) + weights(7) + weights(8) ! fractional position along z
+
+                ! l   ks(l) js(l) is(l)
+                ! 1   k     j     i
+                ! 2   k     j     i+1
+                ! 3   k     j+1   i
+                ! 4   k     j+1   i+1
+                ! 5   k+1   j     i
+                ! 6   k+1   j     i+1
+                ! 7   k+1   j+1   i
+                ! 8   k+1   j+1   i+1
+                lim_x = dx(1) * xf * (one - xf)
+                xs = - prefactor * lim_x * (&
+                            (one - zf) * (&
+                                    (one - yf) * (phi(ks(2), js(2), is(2)) - phi(ks(1), js(1), is(1)))  &
+                                  +       (yf) * (phi(ks(4), js(4), is(4)) - phi(ks(3), js(3), is(3)))) &
+                          +      (zf) * (&
+                                    (one - yf) * (phi(ks(6), js(6), is(6)) - phi(ks(5), js(5), is(5)))  &
+                                  +       (yf) * (phi(ks(8), js(8), is(8)) - phi(ks(7), js(7), is(7)))))
+
+                lim_x = lim_x * max_compression
+                xs = max(-lim_x, min(xs, lim_x))
+
+                lim_y = dx(2) * yf * (one - yf)
+                ys = - prefactor * lim_y * (&
+                            (one - zf) * (&
+                                    (one - xf) * (phi(ks(3), js(3), is(3)) - phi(ks(1), js(1), is(1)))  &
+                                  +       (xf) * (phi(ks(4), js(4), is(4)) - phi(ks(2), js(2), is(2)))) &
+                          +      (zf) * (&
+                                    (one - xf) * (phi(ks(7), js(7), is(7)) - phi(ks(5), js(5), is(5)))  &
+                                  +       (xf) * (phi(ks(8), js(8), is(8)) - phi(ks(6), js(6), is(6)))))
+
+                lim_y = lim_y * max_compression
+                ys = max(-lim_y, min(ys, lim_y))
+
+                lim_z = dx(3) * zf * (one - zf)
+                zs = - prefactor * lim_z * (&
+                            (one - xf) * (&
+                                    (one - yf) * (phi(ks(5), js(5), is(5)) - phi(ks(1), js(1), is(1)))  &
+                                  +       (yf) * (phi(ks(7), js(7), is(7)) - phi(ks(3), js(3), is(3)))) &
+                          +      (xf) * (&
+                                    (one - yf) * (phi(ks(6), js(6), is(6)) - phi(ks(2), js(2), is(2)))  &
+                                  +       (yf) * (phi(ks(8), js(8), is(8)) - phi(ks(4), js(4), is(4)))))
+
+                lim_z = lim_z * max_compression
+                zs = max(-lim_z, min(zs, lim_z))
+
+                parcels%position(1, n) = parcels%position(1, n) + xs
+                parcels%position(2, n) = parcels%position(2, n) + ys
+                parcels%position(3, n) = parcels%position(3, n) + zs
+            enddo
+            !$omp end do
+            !$omp end parallel
+
+            call stop_timer(grad_corr_timer)
+
+        end subroutine apply_gradient
 
 end module parcel_correction

--- a/src/3d/parcels/parcel_correction.f90
+++ b/src/3d/parcels/parcel_correction.f90
@@ -41,6 +41,7 @@ module parcel_correction
             call start_timer(vort_corr_timer)
 
             vsum = zero
+            vor_bar = zero
 
             !$omp parallel default(shared)
             !$omp do private(n) reduction(+: vor_bar, vsum)

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -36,8 +36,6 @@ module parcel_diagnostics
     ! rms vorticity
     double precision :: rms_zeta(3)
 
-    double precision :: xi_bar, eta_bar
-
     contains
 
         ! Compute the reference potential energy
@@ -56,25 +54,13 @@ module parcel_diagnostics
             gam = one / (extent(1) * extent(2))
             zmean = gam * parcels%volume(ii(1))
 
-            xi_bar = parcels%vorticity(1, 1) * parcels%volume(1)
-            eta_bar = parcels%vorticity(2, 1) * parcels%volume(1)
-            vsum = parcels%volume(1)
-
             peref = - b(1) * parcels%volume(ii(1)) * zmean
             do n = 2, n_parcels
                 zmean = zmean + gam * (parcels%volume(ii(n-1)) + parcels%volume(ii(n)))
 
                 peref = peref &
                       - b(n) * parcels%volume(ii(n)) * zmean
-
-                xi_bar = xi_bar + parcels%vorticity(1, n) * parcels%volume(n)
-                eta_bar = eta_bar + parcels%vorticity(2, n) * parcels%volume(n)
-                vsum = vsum + parcels%volume(n)
             enddo
-
-            xi_bar = xi_bar / vsum
-            eta_bar = eta_bar / vsum
-
 
             call stop_timer(parcel_stats_timer)
         end subroutine init_parcel_diagnostics

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -42,7 +42,7 @@ module parcel_diagnostics
         subroutine init_parcel_diagnostics
             integer          :: ii(n_parcels), n
             double precision :: b(n_parcels)
-            double precision :: gam, zmean, vsum
+            double precision :: gam, zmean
 
             call start_timer(parcel_stats_timer)
 

--- a/src/3d/parcels/parcel_diagnostics.f90
+++ b/src/3d/parcels/parcel_diagnostics.f90
@@ -36,13 +36,15 @@ module parcel_diagnostics
     ! rms vorticity
     double precision :: rms_zeta(3)
 
+    double precision :: xi_bar, eta_bar
+
     contains
 
         ! Compute the reference potential energy
         subroutine init_parcel_diagnostics
             integer          :: ii(n_parcels), n
             double precision :: b(n_parcels)
-            double precision :: gam, zmean
+            double precision :: gam, zmean, vsum
 
             call start_timer(parcel_stats_timer)
 
@@ -54,13 +56,25 @@ module parcel_diagnostics
             gam = one / (extent(1) * extent(2))
             zmean = gam * parcels%volume(ii(1))
 
+            xi_bar = parcels%vorticity(1, 1) * parcels%volume(1)
+            eta_bar = parcels%vorticity(2, 1) * parcels%volume(1)
+            vsum = parcels%volume(1)
+
             peref = - b(1) * parcels%volume(ii(1)) * zmean
             do n = 2, n_parcels
                 zmean = zmean + gam * (parcels%volume(ii(n-1)) + parcels%volume(ii(n)))
 
                 peref = peref &
                       - b(n) * parcels%volume(ii(n)) * zmean
+
+                xi_bar = xi_bar + parcels%vorticity(1, n) * parcels%volume(n)
+                eta_bar = eta_bar + parcels%vorticity(2, n) * parcels%volume(n)
+                vsum = vsum + parcels%volume(n)
             enddo
+
+            xi_bar = xi_bar / vsum
+            eta_bar = eta_bar / vsum
+
 
             call stop_timer(parcel_stats_timer)
         end subroutine init_parcel_diagnostics

--- a/src/3d/parcels/parcel_interpl.f90
+++ b/src/3d/parcels/parcel_interpl.f90
@@ -11,7 +11,7 @@ module parcel_interpl
     use parcel_bc, only : apply_periodic_bc
     use parcel_ellipsoid
     use fields
-    use physics, only : ft_cor, f_cor, glat, lambda_c, q_0
+    use physics, only : glat, lambda_c, q_0
     use omp_lib
     implicit none
 
@@ -251,7 +251,7 @@ module parcel_interpl
             do p = 1, 3
                 vortg(0:nz, :, :, p) = vortg(0:nz, :, :, p) / volg(0:nz, :, :)
             enddo
-             
+
             ! use symmetry to fill halo grid points
             vortg(-1,   :, :, :) = vortg(1,    :, :, :)
             vortg(nz+1, :, :, :) = vortg(nz-1, :, :, :)

--- a/src/3d/parcels/parcel_interpl.f90
+++ b/src/3d/parcels/parcel_interpl.f90
@@ -236,6 +236,10 @@ module parcel_interpl
             vortg(1,    :, :, :) = vortg(1,    :, :, :) + vortg(-1,   :, :, :)
             vortg(nz-1, :, :, :) = vortg(nz-1, :, :, :) + vortg(nz+1, :, :, :)
 
+            ! use symmetry to fill halo grid points
+            vortg(-1,   :, :, :) = vortg(1,    :, :, :)
+            vortg(nz+1, :, :, :) = vortg(nz-1, :, :, :)
+
 #ifndef ENABLE_DRY_MODE
             dbuoyg(0,  :, :) = two * dbuoyg(0,  :, :)
             dbuoyg(nz, :, :) = two * dbuoyg(nz, :, :)

--- a/src/3d/stepper/ls_rk4.f90
+++ b/src/3d/stepper/ls_rk4.f90
@@ -80,7 +80,7 @@ module ls_rk4
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
             ! update the time step
             dt = get_time_step(t)
@@ -146,7 +146,7 @@ module ls_rk4
             else
                 call vor2vel(vortg, velog, velgradg)
 
-                call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
+                call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
                 call grid2par_add(delta_pos, delta_vor, strain)
 

--- a/src/3d/stepper/ls_rk4.f90
+++ b/src/3d/stepper/ls_rk4.f90
@@ -80,7 +80,7 @@ module ls_rk4
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, tbuoyg, velgradg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
             ! update the time step
             dt = get_time_step(t)
@@ -146,7 +146,7 @@ module ls_rk4
             else
                 call vor2vel(vortg, velog, velgradg)
 
-                call vorticity_tendency(vortg, tbuoyg, velgradg, vtend)
+                call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
                 call grid2par_add(delta_pos, delta_vor, strain)
 

--- a/src/3d/stepper/ls_rk4.f90
+++ b/src/3d/stepper/ls_rk4.f90
@@ -80,7 +80,7 @@ module ls_rk4
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
 
             ! update the time step
             dt = get_time_step(t)
@@ -146,7 +146,7 @@ module ls_rk4
             else
                 call vor2vel(vortg, velog, velgradg)
 
-                call vorticity_tendency(vortg, velog, tbuoyg, vtend)
+                call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
 
                 call grid2par_add(delta_pos, delta_vor, strain)
 

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -69,7 +69,7 @@ module utils
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, tbuoyg, velgradg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
             call grid2par(velocity, vorticity, strain)
 

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -69,7 +69,7 @@ module utils
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
             call grid2par(velocity, vorticity, strain)
 

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -69,7 +69,7 @@ module utils
             ! this is also needed for the first ls-rk4 substep
             call vor2vel(vortg, velog, velgradg)
 
-            call vorticity_tendency(vortg, velog, tbuoyg, vtend)
+            call vorticity_tendency(vortg, velog, tbuoyg, velgradg, vtend)
 
             call grid2par(velocity, vorticity, strain)
 

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -56,7 +56,7 @@ module physics
     ![rad/s] default value: angular velocity of the earth
     double precision :: ang_vel = 0.000072921d0
 
-    logical, protected  :: l_coriolis = .false.
+    logical, protected  :: l_planet_vorticity = .false.
 
     ![°] latitude angle (45° corresponds to standard gravity)
     double precision, protected  :: lat_degrees = 45.0d0
@@ -82,7 +82,7 @@ module physics
     ! MPIC specific
     double precision, protected :: glati
 
-    ! Coriolis frequency (all three components)
+    ! planetary vorticity (all three components)
     double precision, protected :: f_cor(3)
 
     interface print_physical_quantity
@@ -108,14 +108,14 @@ module physics
             logical                  :: exists = .false.
 
             ! namelist definitions
-            namelist /PHYSICS/ gravity,     &
-                               L_v,         &
-                               c_p,         &
-                               theta_0,     &
-                               ang_vel,     &
-                               l_coriolis,  &
-                               lat_degrees, &
-                               q_0,         &
+            namelist /PHYSICS/ gravity,             &
+                               L_v,                 &
+                               c_p,                 &
+                               theta_0,             &
+                               ang_vel,             &
+                               l_planet_vorticity,  &
+                               lat_degrees,         &
+                               q_0,                 &
                                height_c
 
             ! check whether file exists
@@ -151,7 +151,7 @@ module physics
 
             lambda_c = one / height_c
 
-            if (l_coriolis) then
+            if (l_planet_vorticity) then
                 lat_ref = lat_degrees * deg2rad
                 f_cor(1) = zero
                 f_cor(2) = two * ang_vel * dcos(lat_ref)
@@ -174,7 +174,7 @@ module physics
                 call read_netcdf_attribute_default(grp_ncid, 'temperature_at_sea_level', theta_0)
                 call read_netcdf_attribute_default(grp_ncid, 'planetary_angular_velocity', ang_vel)
                 call read_netcdf_attribute_default(grp_ncid, 'saturation_specific_humidity_at_ground_level', q_0)
-                call read_netcdf_attribute_default(grp_ncid, 'coriolis', l_coriolis)
+                call read_netcdf_attribute_default(grp_ncid, 'planetary_vorticity', l_planet_vorticity)
                 call read_netcdf_attribute_default(grp_ncid, 'latitude_degrees', lat_degrees)
                 call read_netcdf_attribute_default(grp_ncid, 'scale_height', height_c)
 #ifdef ENABLE_VERBOSE
@@ -202,7 +202,7 @@ module physics
             call write_netcdf_attribute(grp_ncid, 'temperature_at_sea_level', theta_0)
             call write_netcdf_attribute(grp_ncid, 'planetary_angular_velocity', ang_vel)
             call write_netcdf_attribute(grp_ncid, 'saturation_specific_humidity_at_ground_level', q_0)
-            call write_netcdf_attribute(grp_ncid, 'coriolis', l_coriolis)
+            call write_netcdf_attribute(grp_ncid, 'planet_vorticity', l_planet_vorticity)
             call write_netcdf_attribute(grp_ncid, 'latitude_degrees', lat_degrees)
             call write_netcdf_attribute(grp_ncid, 'scale_height', height_c)
 
@@ -217,9 +217,9 @@ module physics
             call print_physical_quantity('temperature at sea level', theta_0, 'K')
             call print_physical_quantity('planetary angular velocity', ang_vel, 'rad/s')
             call print_physical_quantity('saturation specific humidity at ground level', q_0)
-            call print_physical_quantity('coriolis', l_coriolis)
-            call print_physical_quantity('vertical Coriolis frequency', f_cor(3), '1/s')
-            call print_physical_quantity('horizontal component of the Coriolis frequency', f_cor(2), '1/s')
+            call print_physical_quantity('planetary vorticity', l_planet_vorticity)
+            call print_physical_quantity('vertical planetary vorticity', f_cor(3), '1/s')
+            call print_physical_quantity('horizontal planetary vorticity', f_cor(2), '1/s')
             call print_physical_quantity('latitude degrees', lat_degrees, 'deg')
             call print_physical_quantity('scale height', height_c, 'm')
             call print_physical_quantity('inverse scale height', lambda_c, '1/m')

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -82,7 +82,7 @@ module physics
     ! MPIC specific
     double precision, protected :: glati
 
-    ! Coriolis frequency, planetary vorticity
+    ! Coriolis frequency (all three components)
     double precision, protected :: f_cor(3)
 
     interface print_physical_quantity
@@ -155,9 +155,9 @@ module physics
                 lat_ref = lat_degrees * deg2rad
                 f_cor(1) = zero
                 f_cor(2) = two * ang_vel * dcos(lat_ref)
-                f_cor(3)  = two * ang_vel * dsin(lat_ref)
+                f_cor(3) = two * ang_vel * dsin(lat_ref)
             else
-                f_cor  = zero
+                f_cor = zero
             endif
         end subroutine update_physical_quantities
 
@@ -218,8 +218,8 @@ module physics
             call print_physical_quantity('planetary angular velocity', ang_vel, 'rad/s')
             call print_physical_quantity('saturation specific humidity at ground level', q_0)
             call print_physical_quantity('coriolis', l_coriolis)
-            call print_physical_quantity('coriolis frequency', f_cor(3), '1/s')
-            call print_physical_quantity('planetary vorticity', f_cor(2), '1/s')
+            call print_physical_quantity('vertical Coriolis frequency', f_cor(3), '1/s')
+            call print_physical_quantity('horizontal component of the Coriolis frequency', f_cor(2), '1/s')
             call print_physical_quantity('latitude degrees', lat_degrees, 'deg')
             call print_physical_quantity('scale height', height_c, 'm')
             call print_physical_quantity('inverse scale height', lambda_c, '1/m')

--- a/src/utils/physics.f90
+++ b/src/utils/physics.f90
@@ -82,11 +82,8 @@ module physics
     ! MPIC specific
     double precision, protected :: glati
 
-    ! Coriolis frequency
-    double precision, protected :: f_cor
-
-    ! component of the planetary vorticity in the y direction
-    double precision, protected :: ft_cor
+    ! Coriolis frequency, planetary vorticity
+    double precision, protected :: f_cor(3)
 
     interface print_physical_quantity
         module procedure :: print_physical_quantity_double
@@ -156,11 +153,11 @@ module physics
 
             if (l_coriolis) then
                 lat_ref = lat_degrees * deg2rad
-                f_cor  = two * ang_vel * dsin(lat_ref)
-                ft_cor = two * ang_vel * dcos(lat_ref)
+                f_cor(1) = zero
+                f_cor(2) = two * ang_vel * dcos(lat_ref)
+                f_cor(3)  = two * ang_vel * dsin(lat_ref)
             else
                 f_cor  = zero
-                ft_cor = zero
             endif
         end subroutine update_physical_quantities
 
@@ -221,8 +218,8 @@ module physics
             call print_physical_quantity('planetary angular velocity', ang_vel, 'rad/s')
             call print_physical_quantity('saturation specific humidity at ground level', q_0)
             call print_physical_quantity('coriolis', l_coriolis)
-            call print_physical_quantity('coriolis frequency', f_cor, '1/s')
-            call print_physical_quantity('planetary vorticity', ft_cor, '1/s')
+            call print_physical_quantity('coriolis frequency', f_cor(3), '1/s')
+            call print_physical_quantity('planetary vorticity', f_cor(2), '1/s')
             call print_physical_quantity('latitude degrees', lat_degrees, 'deg')
             call print_physical_quantity('scale height', height_c, 'm')
             call print_physical_quantity('inverse scale height', lambda_c, '1/m')

--- a/src/utils/timer.f90
+++ b/src/utils/timer.f90
@@ -16,7 +16,7 @@ module timer
         integer(8)        :: cr1, cr2
     end type timer_type
 
-    type(timer_type) :: timings(20)
+    type(timer_type) :: timings(21)
 
     integer :: n_timers = 0
 

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -43,6 +43,7 @@ unittests_PROGRAMS = 				\
 	test_free_slip_3d			\
 	test_vor2vel				\
 	test_velgradg				\
+	test_vtend				\
 	test_lapinv0_1				\
 	test_lapinv0_2				\
 	test_lapinv1				\
@@ -111,6 +112,9 @@ test_vor2vel_LDADD = libcombi.la
 
 test_velgradg_SOURCES = test_velgradg.f90
 test_velgradg_LDADD = libcombi.la
+
+test_vtend_SOURCES = test_vtend.f90
+test_vtend_LDADD = libcombi.la
 
 test_lapinv0_1_SOURCES = test_lapinv0_1.f90
 test_lapinv0_1_LDADD = libcombi.la

--- a/unit-tests/3d/test_gradient_correction_3d.f90
+++ b/unit-tests/3d/test_gradient_correction_3d.f90
@@ -32,6 +32,7 @@ program test_gradient_correction_3d
     call parse_command_line
 
     call register_timer('gradient correction', lapl_corr_timer)
+    call register_timer('vorticity correction', vort_corr_timer)
 
 
     nx = 16

--- a/unit-tests/3d/test_gradient_correction_3d.f90
+++ b/unit-tests/3d/test_gradient_correction_3d.f90
@@ -31,7 +31,7 @@ program test_gradient_correction_3d
 
     call parse_command_line
 
-    call register_timer('gradient correction', lapl_corr_timer)
+    call register_timer('gradient correction', grad_corr_timer)
     call register_timer('vorticity correction', vort_corr_timer)
 
 

--- a/unit-tests/3d/test_laplace_correction_3d.f90
+++ b/unit-tests/3d/test_laplace_correction_3d.f90
@@ -32,6 +32,7 @@ program test_laplace_correction_3d
     call parse_command_line
 
     call register_timer('laplace correction', lapl_corr_timer)
+    call register_timer('vorticity correction', vort_corr_timer)
 
 
     nx = 16

--- a/unit-tests/3d/test_parcel_correction_3d.f90
+++ b/unit-tests/3d/test_parcel_correction_3d.f90
@@ -33,6 +33,7 @@ program test_parcel_correction_3d
 
     call register_timer('laplace correction', lapl_corr_timer)
     call register_timer('gradient correction', grad_corr_timer)
+    call register_timer('vorticity correction', vort_corr_timer)
 
 
     nx = 16

--- a/unit-tests/3d/test_vor2vel.f90
+++ b/unit-tests/3d/test_vor2vel.f90
@@ -75,7 +75,7 @@ program test_vor2vel_2
 
     error = maxval(dabs(velog_ref(0:nz, :, :, :) - velog(0:nz, :, :, :)))
 
-    call print_result_dp('Test inversion (vorticity)', error, atol=4.0e-7)
+    call print_result_dp('Test inversion (vorticity)', error, atol=2.0e-3)
 
     deallocate(velog_ref)
 

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -55,7 +55,6 @@ program test_vtend
         do il = 1, 3
             l = dble(il)
             do im = 1, 3, 2
-                print *, im
                 m = dble(im)
 
                 alpha = dsqrt(k ** 2 + l ** 2 + m ** 2)
@@ -91,10 +90,9 @@ program test_vtend
                     enddo
                 enddo
 
-
                 call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
-                error = maxval(dabs(vtend_ref(0:nz, :, :, :) - vtend(0:nz, :, :, :)))
+                error = max(error, maxval(dabs(vtend_ref(0:nz, :, :, :) - vtend(0:nz, :, :, :))))
             enddo
         enddo
     enddo

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -72,8 +72,8 @@ program test_vtend
 
                 ! vorticity
                 vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 1)
-                vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 2)
-                vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 3)
+                vortg(iz, iy, ix, 2) = alpha * velog(iz, iy, ix, 2)
+                vortg(iz, iy, ix, 3) = alpha * velog(iz, iy, ix, 3)
 
                 ! reference solution
                 vtend_ref(iz, iy, ix, 1) = 3.0d0 / 8.0d0 * sinkxly

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -60,15 +60,15 @@ program test_vtend
                 sinkxly = dsin(k * x + l * y)
                 coskxly = dcos(k * x + l * y)
 
-                ! vorticity
-                vortg(iz, iy, ix, 1) = fk2l2 * (k * m * sinmz - l * alpha * cosmz) * sinkxly
-                vortg(iz, iy, ix, 2) = fk2l2 * (l * m * sinmz + k * alpha * cosmz) * sinkxly
-                vortg(iz, iy, ix, 3) = alpha * cosmz * coskxly
-
                 ! velocity
-                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 1)
-                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 2)
-                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 3)
+                velog(iz, iy, ix, 1) = fk2l2 * (k * m * sinmz - l * alpha * cosmz) * sinkxly
+                velog(iz, iy, ix, 2) = fk2l2 * (l * m * sinmz + k * alpha * cosmz) * sinkxly
+                velog(iz, iy, ix, 3) = alpha * cosmz * coskxly
+
+                ! vorticity
+                vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 1)
+                vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 2)
+                vortg(iz, iy, ix, 1) = alpha * velog(iz, iy, ix, 3)
             enddo
         enddo
     enddo

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -1,0 +1,86 @@
+! =============================================================================
+!                       Test the vorticity tendency
+!
+!  This unit test checks the calculation of the vorticity tendency using the
+!  Beltrami flow:
+!     u(x, y, z) = (k^2 + l^2)^(-1) * [k*m*sin(mz) - l*alpha*cos(m*z) * sin(k*x + l*y)]
+!     v(x, y, z) = (k^2 + l^2)^(-1) * [l*m*sin(mz) + k*alpha*cos(m*z) * sin(k*x + l*y)]
+!     w(x, y, z) = cos(m*z) * cos(k*x + l*y)
+!  The vorticity of this flow is
+!    xi(x, y, z) = alpha * u(x, y, z)
+!   eta(x, y, z) = alpha * v(x, y, z)
+!  zeta(x, y, z) = alpha * w(x, y, z)
+!  We us k = l = 2 and m = 1
+! =============================================================================
+program test_vtend
+    use unit_test
+    use constants, only : zero, one, two, four, pi, twopi, f12
+    use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
+    use fields, only : vortg, velog, vtend, tbuoyg, field_default
+    use inversion_utils, only : init_fft, fftxyp2s
+    use inversion_mod, only : vor2vel, vor2vel_timer
+    use timer
+    implicit none
+
+    double precision              :: error
+    double precision, allocatable :: vtend_ref(:, :, :, :)
+    integer                       :: ix, iy, iz
+    double precision              :: x, y, z, k, l, m, alpha, fk2l2
+
+    call register_timer('vorticity', vor2vel_timer)
+
+    nx = 64
+    ny = 64
+    nz = 64
+
+    lower  = (/-pi, -pi, -f12 * pi/)
+    extent =  (/twopi, twopi, twopi/)
+
+    k = two
+    l = two
+    m = one
+    alpha = dsqrt(k ** 2 + l ** 2 + m ** 2)
+    fk2l2 = alpha / dble(k ** 2 + l ** 2)
+
+    allocate(vtend_ref(-1:nz+1, 0:ny-1, 0:nx-1, 5))
+
+    call update_parameters
+
+    call field_default
+
+    do ix = 0, nx-1
+        x = lower(1) + ix * dx(1)
+        do iy = 0, ny-1
+            y = lower(2) + iy * dx(2)
+            do iz = -1, nz+1
+                z = lower(3) + iz * dx(3)
+
+                cosmz = dcos(m * z)
+                sinmz = dsin(m * z)
+                sinkxly = dsin(k * x + l * y)
+                coskxly = dcos(k * x + l * y)
+
+                ! vorticity
+                vortg(iz, iy, ix, 1) = fk2l2 * (k * m * sinmz - l * alpha * cosmz) * sinkxly
+                vortg(iz, iy, ix, 2) = fk2l2 * (l * m * sinmz + k * alpha * cosmz) * sinkxly
+                vortg(iz, iy, ix, 3) = alpha * cosmz * coskxly
+
+                ! velocity
+                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 1)
+                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 2)
+                velog(iz, iy, ix, 1) = alpha * vortg(iz, iy, ix, 3)
+            enddo
+        enddo
+    enddo
+
+    call init_fft
+
+    call vorticity_tendency(vortg, velog, tbuoyg, vtend)
+
+!     error = maxval(dabs(velog_ref(0:nz, :, :, :) - velog(0:nz, :, :, :)))
+
+    call print_result_dp('Test vorticity tendency', error, atol=4.0e-7)
+
+    deallocate(vtend_ref)
+
+end program test_vtend

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -17,7 +17,7 @@
 ! =============================================================================
 program test_vtend
     use unit_test
-    use constants, only : zero, one, two, four, pi, twopi, f12
+    use constants, only : one, two, pi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
     use fields, only : vortg, velog, vtend, tbuoyg, field_default
     use inversion_utils, only : init_fft, fftxyp2s
@@ -38,8 +38,8 @@ program test_vtend
     ny = 64
     nz = 64
 
-    lower  = (/-pi, -pi, -f12 * pi/)
-    extent =  (/twopi, twopi, twopi/)
+    lower  = -f12 * pi * (/one, one, one/)
+    extent =  pi * (/one, one, one/)
 
     k = two
     l = two
@@ -88,6 +88,8 @@ program test_vtend
     call vorticity_tendency(vortg, velog, tbuoyg, vtend)
 
     error = maxval(dabs(vtend_ref(0:nz, :, :, :) - vtend(0:nz, :, :, :)))
+
+    print *, error
 
     call print_result_dp('Test vorticity tendency', error, atol=4.0e-7)
 

--- a/unit-tests/3d/test_vtend.f90
+++ b/unit-tests/3d/test_vtend.f90
@@ -76,8 +76,8 @@ program test_vtend
                 vortg(iz, iy, ix, 3) = alpha * velog(iz, iy, ix, 3)
 
                 ! reference solution
-                vtend_ref(iz, iy, ix, 1) = 3.0d0 / 8.0d0 * sinkxly
-                vtend_ref(iz, iy, ix, 2) = 3.0d0 / 8.0d0 * sinkxly
+                vtend_ref(iz, iy, ix, 1) = 3.0d0 / 8.0d0 * dsin(4.0d0 * x + 4.0d0 * y)
+                vtend_ref(iz, iy, ix, 2) = vtend_ref(iz, iy, ix, 1)
                 vtend_ref(iz, iy, ix, 3) = - 3.0d0 / 2.0d0 * dsin(2.0d0 * z)
             enddo
         enddo


### PR DESCRIPTION
This PR
* changes to the new inversion method
* corrects the parcel tendency after each RK4 step to prevent a growth of the net vorticity
* changes to flux form in the vorticity tendency calculation
* introduces symmetry BC for vorticity
* adds writing the gridded volume to file