### PR TITLE
Use central differencing in solenoidal correction and tendency calculation

### DIFF
--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -51,8 +51,7 @@ module inversion_mod
             ds = as - bs                     ! ds = D
             cs = svor(:, :, :, I_Z)
             !$omp end parallel workshare
-!             call diffz(cs, es)               ! es = E
-call field_combine_semi_spectral(cs)
+            call field_combine_semi_spectral(cs)
             call central_diffz(cs, es)                     ! es = E
             call field_decompose_semi_spectral(es)
 
@@ -325,12 +324,6 @@ call field_combine_semi_spectral(cs)
                 vtend(nz, :, :, I_Z) = zero
             endif
 
-!             vtend(0 , :, :, I_X) = zero
-!             vtend(nz, :, :, I_X) = zero
-
-!             vtend(0 , :, :, I_Y) = zero
-!             vtend(nz, :, :, I_Y) = zero
-
             !-------------------------------------------------------
             ! Extrapolate to halo grid points:
             !$omp parallel workshare
@@ -362,9 +355,6 @@ call field_combine_semi_spectral(cs)
             div = div + f(0:nz, :, :, I_Y)
 
             ! calculate df3/dz
-!             call field_decompose_physical(f(0:nz, :, :, I_Z), fs)
-!             call diffz(fs, ds)
-!             call field_combine_physical(ds, f(0:nz, :, :, I_Z))
             call central_diffz(f(0:nz, :, :, I_Z), ds)
             f(0:nz, :, :, I_Z) = ds
 
@@ -405,7 +395,7 @@ call field_combine_semi_spectral(cs)
             call fftxys2p(vs, vd)
 
             ! Compute z derivative by central differences:
-            call central_diffz(ds, ws) ! FIXME wrong spaces
+            call central_diffz(ds, ws)
 
             ! Set vertical boundary values to zero
             ws(0,  :, :) = zero

--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -344,22 +344,18 @@ module inversion_mod
             ! calculate df1/dx
             call fftxyp2s(f(0:nz, :, :, I_X), fs)
             call diffx(fs, ds)
-            call fftxys2p(ds, div)
+            call fftxys2p(ds, f(0:nz, :, :, I_X))
 
             ! calculate df2/dy
             call fftxyp2s(f(0:nz, :, :, I_Y), fs)
             call diffy(fs, ds)
             call fftxys2p(ds, f(0:nz, :, :, I_Y))
 
-            ! div = df1/dx + df2/dy
-            div = div + f(0:nz, :, :, I_Y)
-
             ! calculate df3/dz
-            call central_diffz(f(0:nz, :, :, I_Z), ds)
-            f(0:nz, :, :, I_Z) = ds
+            call central_diffz(f(0:nz, :, :, I_Z), div)
 
             ! div = df1/dx + df2/dy + df3/dz
-            div = div + f(0:nz, :, :, I_Z)
+            div = f(0:nz, :, :, I_X) + f(0:nz, :, :, I_Y) + div
 
           end subroutine divergence
 

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -525,8 +525,8 @@ module inversion_utils
         !Calculates df/dz for a field f using 2nd-order differencing.
         !Here fs = f, ds = df/dz. In semi-spectral space or physical space.
         subroutine central_diffz(fs, ds)
-            double precision, intent(in)  :: fs(0:nz, :, :)
-            double precision, intent(out) :: ds(0:nz, :, :)
+            double precision, intent(in)  :: fs(0:, 0:, 0:)
+            double precision, intent(out) :: ds(0:, 0:, 0:)
             integer                       :: iz
 
             ! Quadratic extrapolation at boundaries:
@@ -557,7 +557,7 @@ module inversion_utils
         !Calculates df/dz for a field f in mixed-spectral space
         !Here fs = f, ds = df/dz. Both fields are in mixed-spectral space.
         subroutine diffz(fs, ds)
-            double precision, intent(inout)  :: fs(0:nz, 0:nx-1, 0:ny-1) ! f in mixed-spectral space
+            double precision, intent(in)  :: fs(0:nz, 0:nx-1, 0:ny-1) ! f in mixed-spectral space
             double precision, intent(out) :: ds(0:nz, 0:nx-1, 0:ny-1) ! derivative linear part
             double precision              :: as(0:nz, 0:nx-1, 0:ny-1) ! derivative sine-part
             integer                       :: kx, ky, kz, iz

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -523,17 +523,17 @@ module inversion_utils
         !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
         !Calculates df/dz for a field f using 2nd-order differencing.
-        !Here fs = f, ds = df/dz. In semi-spectral space.
+        !Here fs = f, ds = df/dz. In semi-spectral space or physical space.
         subroutine central_diffz(fs, ds)
-            double precision, intent(in)  :: fs(0:nz, 0:ny-1, 0:nx-1)
-            double precision, intent(out) :: ds(0:nz, 0:ny-1, 0:nx-1)
+            double precision, intent(in)  :: fs(0:nz, :, :)
+            double precision, intent(out) :: ds(0:nz, :, :)
             integer                       :: iz
 
             ! Quadratic extrapolation at boundaries:
-!             !$omp parallel workshare
+            !$omp parallel workshare
             ds(0,  :, :) = hdzi * (four * fs(1,  :, :) - three * fs(0,    :, :) - fs(2, :, :))
             ds(nz, :, :) = hdzi * (three * fs(nz, :, :) - four * fs(nz-1, :, :) + fs(nz-2, :, :))
-!             !$omp end parallel workshare
+            !$omp end parallel workshare
 
 !             ! Linear extrapolation at the boundaries:
 !             ! iz = 0:  (fs(1) - fs(0)) / dz

--- a/src/3d/inversion/inversion_utils.f90
+++ b/src/3d/inversion/inversion_utils.f90
@@ -152,8 +152,8 @@ module inversion_utils
             phim(:, 0, 0) = zm / extent(3)
             phip(:, 0, 0) = zp / extent(3)
 
-            dphim(:, 0, 0) = zero
-            dphip(:, 0, 0) = zero
+            dphim(:, 0, 0) = - one / extent(3)
+            dphip(:, 0, 0) =   one / extent(3)
 
             thetam(:, 0, 0) = zero
             thetap(:, 0, 0) = zero

--- a/src/3d/parcels/parcel_interpl.f90
+++ b/src/3d/parcels/parcel_interpl.f90
@@ -246,12 +246,6 @@ module parcel_interpl
                 vortg(nz, :, :, I_Z) = zero
             endif
 
-!             vortg(0,  :, :, I_X) = zero
-!             vortg(nz, :, :, I_X) = zero
-
-!             vortg(0,  :, :, I_Y) = zero
-!             vortg(nz, :, :, I_Y) = zero
-
             !$omp parallel workshare
             vortg(-1,   :, :, :) = two * vortg(0,  :, :, :) - vortg(1, :, :, :)
             vortg(nz+1, :, :, :) = two * vortg(nz, :, :, :) - vortg(nz-1, :, :, :)

--- a/src/3d/parcels/parcel_interpl.f90
+++ b/src/3d/parcels/parcel_interpl.f90
@@ -246,6 +246,12 @@ module parcel_interpl
                 vortg(nz, :, :, I_Z) = zero
             endif
 
+!             vortg(0,  :, :, I_X) = zero
+!             vortg(nz, :, :, I_X) = zero
+
+!             vortg(0,  :, :, I_Y) = zero
+!             vortg(nz, :, :, I_Y) = zero
+
             !$omp parallel workshare
             vortg(-1,   :, :, :) = two * vortg(0,  :, :, :) - vortg(1, :, :, :)
             vortg(nz+1, :, :, :) = two * vortg(nz, :, :, :) - vortg(nz-1, :, :, :)

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -50,7 +50,10 @@ unittests_PROGRAMS = 				\
 	test_lapinv1				\
 	test_diffz0				\
 	test_diffz1				\
-	test_diffz2
+	test_diffz2				\
+	test_diffz3				\
+	test_diffz4				\
+	test_diffz5
 
 dataroot_DATA =		\
 	numpy_eigh.py 	\
@@ -138,3 +141,12 @@ test_diffz1_LDADD = libcombi.la
 
 test_diffz2_SOURCES = test_diffz2.f90
 test_diffz2_LDADD = libcombi.la
+
+test_diffz3_SOURCES = test_diffz3.f90
+test_diffz3_LDADD = libcombi.la
+
+test_diffz4_SOURCES = test_diffz4.f90
+test_diffz4_LDADD = libcombi.la
+
+test_diffz5_SOURCES = test_diffz5.f90
+test_diffz5_LDADD = libcombi.la

--- a/unit-tests/3d/Makefile.am
+++ b/unit-tests/3d/Makefile.am
@@ -49,7 +49,8 @@ unittests_PROGRAMS = 				\
 	test_vtend				\
 	test_lapinv1				\
 	test_diffz0				\
-	test_diffz1
+	test_diffz1				\
+	test_diffz2
 
 dataroot_DATA =		\
 	numpy_eigh.py 	\
@@ -134,3 +135,6 @@ test_diffz0_LDADD = libcombi.la
 
 test_diffz1_SOURCES = test_diffz1.f90
 test_diffz1_LDADD = libcombi.la
+
+test_diffz2_SOURCES = test_diffz2.f90
+test_diffz2_LDADD = libcombi.la

--- a/unit-tests/3d/test_diffz2.f90
+++ b/unit-tests/3d/test_diffz2.f90
@@ -1,0 +1,78 @@
+! =============================================================================
+!                       Test subroutine diffz
+!
+!  This unit test checks the subroutine diffz and central_diffz using the
+!  function:
+!               cos(x) cos(y) cos(z)
+!  in a domain of width 2 * pi in x and y, and of height pi (0 < z < pi)
+!  The subroutine diffz and central_diffz should return
+!               - cos(x) cos(y) sin(z)
+! =============================================================================
+program test_diffz2
+    use unit_test
+    use constants, only : zero, one, two, pi, twopi
+    use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
+    use inversion_utils, only : init_inversion, central_diffz, diffz &
+                              , field_combine_physical, field_decompose_physical
+    implicit none
+
+    double precision              :: error
+    double precision, allocatable :: fs(:, :, :), fp(:, :, :), &
+                                     ds(:, :, :), dp(:, :, :), &
+                                     ref_sol(:, :, :)
+    integer                       :: ix, iy, iz
+    double precision              :: x, y, z
+
+    ! doubling nx, ny, nz reduces the error by a factor 16
+    nx = 64
+    ny = 64
+    nz = 32
+    lower  = (/zero, zero, zero/)
+    extent =  (/twopi, twopi, pi/)
+
+    allocate(fp(0:nz, ny, nx))
+    allocate(dp(0:nz, ny, nx))
+    allocate(fs(0:nz, nx, ny))
+    allocate(ds(0:nz, nx, ny))
+    allocate(ref_sol(0:nz, ny, nx))
+
+    call update_parameters
+
+    do ix = 1, nx
+        x = lower(1) + (ix - 1) * dx(1)
+        do iy = 1, ny
+            y = lower(2) + (iy - 1) * dx(2)
+            do iz = 0, nz
+                z = lower(3) + iz * dx(3)
+
+                fp(iz, iy, ix) = dcos(x) * dcos(y) * dsin(z)
+                ref_sol(iz, iy, ix) = dcos(x) * dcos(y) * dcos(z)
+            enddo
+        enddo
+    enddo
+
+    call init_inversion
+
+    call central_diffz(fp, dp)
+
+    error = maxval(dabs(dp - ref_sol))
+
+    print *, "central", error
+
+    call field_decompose_physical(fp, fs)
+    call diffz(fs, ds)
+    call field_combine_physical(ds, dp)
+
+    error = maxval(dabs(dp - ref_sol))
+
+    print *, "exact", error
+
+    call print_result_dp('Test diffz', error, atol=5.0e-4)
+
+    deallocate(fp)
+    deallocate(dp)
+    deallocate(fs)
+    deallocate(ds)
+    deallocate(ref_sol)
+
+end program test_diffz2

--- a/unit-tests/3d/test_diffz3.f90
+++ b/unit-tests/3d/test_diffz3.f90
@@ -3,10 +3,10 @@
 !
 !  This unit test checks the subroutine diffz and central_diffz using the
 !  function:
-!               cos(x) cos(y) cos(z)
-!  in a domain of width 2 * pi in x and y, and of height pi (0 < z < pi)
+!               z
+!  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
 !  The subroutine diffz and central_diffz should return
-!               - cos(x) cos(y) sin(z)
+!               1
 ! =============================================================================
 program test_diffz2
     use unit_test
@@ -21,13 +21,13 @@ program test_diffz2
     double precision, allocatable :: fs(:, :, :), fp(:, :, :), &
                                      ds(:, :, :), dp(:, :, :), &
                                      ref_sol(:, :, :)
-    integer                       :: ix, iy, iz
-    double precision              :: x, y, z
+    integer                       :: iz
+    double precision              :: z
 
     nx = 128
     ny = 128
     nz = 64
-    lower  = (/zero, zero, zero/)
+    lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
     allocate(fp(0:nz, ny, nx))
@@ -38,16 +38,10 @@ program test_diffz2
 
     call update_parameters
 
-    do ix = 1, nx
-        x = lower(1) + (ix - 1) * dx(1)
-        do iy = 1, ny
-            y = lower(2) + (iy - 1) * dx(2)
-            do iz = 0, nz
-                z = lower(3) + dble(iz) * dx(3)
-                fp(iz, iy, ix) = dcos(x) * dcos(y) * dcos(z)
-                ref_sol(iz, iy, ix) = -dcos(x) * dcos(y) * dsin(z)
-            enddo
-        enddo
+    do iz = 0, nz
+        z = lower(3) + dble(iz) * dx(3)
+        fp(iz, :, :) = z
+        ref_sol(iz, :, :) = one
     enddo
 
     call init_inversion

--- a/unit-tests/3d/test_diffz4.f90
+++ b/unit-tests/3d/test_diffz4.f90
@@ -3,10 +3,10 @@
 !
 !  This unit test checks the subroutine diffz and central_diffz using the
 !  function:
-!               cos(x) cos(y) cos(z)
-!  in a domain of width 2 * pi in x and y, and of height pi (0 < z < pi)
+!               z^2
+!  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
 !  The subroutine diffz and central_diffz should return
-!               - cos(x) cos(y) sin(z)
+!               2z
 ! =============================================================================
 program test_diffz2
     use unit_test
@@ -21,13 +21,13 @@ program test_diffz2
     double precision, allocatable :: fs(:, :, :), fp(:, :, :), &
                                      ds(:, :, :), dp(:, :, :), &
                                      ref_sol(:, :, :)
-    integer                       :: ix, iy, iz
-    double precision              :: x, y, z
+    integer                       :: iz
+    double precision              :: z
 
     nx = 128
     ny = 128
     nz = 64
-    lower  = (/zero, zero, zero/)
+    lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
     allocate(fp(0:nz, ny, nx))
@@ -38,16 +38,10 @@ program test_diffz2
 
     call update_parameters
 
-    do ix = 1, nx
-        x = lower(1) + (ix - 1) * dx(1)
-        do iy = 1, ny
-            y = lower(2) + (iy - 1) * dx(2)
-            do iz = 0, nz
-                z = lower(3) + dble(iz) * dx(3)
-                fp(iz, iy, ix) = dcos(x) * dcos(y) * dcos(z)
-                ref_sol(iz, iy, ix) = -dcos(x) * dcos(y) * dsin(z)
-            enddo
-        enddo
+    do iz = 0, nz
+        z = lower(3) + dble(iz) * dx(3)
+        fp(iz, :, :) = z ** 2
+        ref_sol(iz, :, :) = two * z
     enddo
 
     call init_inversion

--- a/unit-tests/3d/test_diffz5.f90
+++ b/unit-tests/3d/test_diffz5.f90
@@ -3,14 +3,14 @@
 !
 !  This unit test checks the subroutine diffz and central_diffz using the
 !  function:
-!               cos(x) cos(y) cos(z)
-!  in a domain of width 2 * pi in x and y, and of height pi (0 < z < pi)
+!               z^3
+!  in a domain of width 2 * pi in x and y, and of height pi (-pi/2 < z < pi/2)
 !  The subroutine diffz and central_diffz should return
-!               - cos(x) cos(y) sin(z)
+!               3z^2
 ! =============================================================================
 program test_diffz2
     use unit_test
-    use constants, only : zero, one, two, pi, twopi, f12
+    use constants, only : zero, three, pi, twopi, f12
     use parameters, only : lower, update_parameters, dx, nx, ny, nz, extent
     use inversion_utils, only : init_inversion, central_diffz, diffz &
                               , field_combine_physical, field_decompose_physical, fftxyp2s, fftxys2p &
@@ -21,13 +21,13 @@ program test_diffz2
     double precision, allocatable :: fs(:, :, :), fp(:, :, :), &
                                      ds(:, :, :), dp(:, :, :), &
                                      ref_sol(:, :, :)
-    integer                       :: ix, iy, iz
-    double precision              :: x, y, z
+    integer                       :: iz
+    double precision              :: z
 
     nx = 128
     ny = 128
     nz = 64
-    lower  = (/zero, zero, zero/)
+    lower  = (/zero, zero, -f12 * pi/)
     extent =  (/twopi, twopi, pi/)
 
     allocate(fp(0:nz, ny, nx))
@@ -38,16 +38,10 @@ program test_diffz2
 
     call update_parameters
 
-    do ix = 1, nx
-        x = lower(1) + (ix - 1) * dx(1)
-        do iy = 1, ny
-            y = lower(2) + (iy - 1) * dx(2)
-            do iz = 0, nz
-                z = lower(3) + dble(iz) * dx(3)
-                fp(iz, iy, ix) = dcos(x) * dcos(y) * dcos(z)
-                ref_sol(iz, iy, ix) = -dcos(x) * dcos(y) * dsin(z)
-            enddo
-        enddo
+    do iz = 0, nz
+        z = lower(3) + dble(iz) * dx(3)
+        fp(iz, :, :) = z ** 3
+        ref_sol(iz, :, :) = three * z ** 2
     enddo
 
     call init_inversion
@@ -63,10 +57,9 @@ program test_diffz2
     call diffz(fs, ds)
     call field_combine_physical(ds, dp)
 
-
     error = max(error, maxval(dabs(dp - ref_sol)))
 
-    call print_result_dp('Test diffz', error, atol=4.0e-2)
+    call print_result_dp('Test diffz', error, atol=2.0e-1)
 
     deallocate(fp)
     deallocate(dp)


### PR DESCRIPTION
This PR
- use FD for performing vertical derivatives
- fixes the subroutine diffz
- adds more unit tests for diffz and central_diffz