### PR TITLE
Fix verbose mode and update initialisation in parcel correction unit tests

### DIFF
--- a/src/3d/inversion/inversion.f90
+++ b/src/3d/inversion/inversion.f90
@@ -375,7 +375,7 @@ module inversion_mod
 
             ds(:, 1, 1) = zero
 
-            ! Invert Laplace's operator semi-spectrally with compact differences:
+            ! Invert Laplace's operator semi-spectrally:
             call lapinv1(ds)
 
             ! Compute x derivative spectrally:

--- a/unit-tests/2d/test_gradient_correction.f90
+++ b/unit-tests/2d/test_gradient_correction.f90
@@ -90,13 +90,13 @@ program test_parcel_correction
 
     init_error = sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1))
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=12, file='test_gradient_correction.asc', status='replace')
         write(12,*) '# iteration, average error, max absolute error'
         write(12,*) 0, init_error, maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
     endif
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=1235, file='initial_gradient_corr.asc', status='replace')
         write(1235, *) '# x, y volume B11, B22'
         do n = 1, n_parcels
@@ -109,13 +109,13 @@ program test_parcel_correction
 
     do i = 1, 20
         call apply_gradient(1.80d0,0.5d0)
-        if (verbose) then
+        if (l_verbose) then
             call vol2grid
             write(12, *) i, sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1)), &
                             maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
         endif
 
-        if (verbose .and. (i == 2)) then
+        if (l_verbose .and. (i == 2)) then
             open(unit=1236, file='two_iter_gradient_corr.asc', status='replace')
             write(1236, *) '# x, y volume B11, B22'
             do n = 1, n_parcels
@@ -125,7 +125,7 @@ program test_parcel_correction
         endif
     enddo
 
-    if (verbose) then
+    if (l_verbose) then
         close(12)
     endif
 

--- a/unit-tests/2d/test_laplace_correction.f90
+++ b/unit-tests/2d/test_laplace_correction.f90
@@ -90,13 +90,13 @@ program test_laplace_correction
 
     init_error = sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1))
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=12, file='test_laplace_correction.asc', status='replace')
         write(12,*) '# iteration, average error, max absolute error'
         write(12,*) 0, init_error, maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
     endif
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=1235, file='initial_laplace_corr.asc', status='replace')
         write(1235, *) '# x, y volume B11, B22'
         do n = 1, n_parcels
@@ -109,13 +109,13 @@ program test_laplace_correction
 
     do i = 1, 20
         call apply_laplace
-        if (verbose) then
+        if (l_verbose) then
             call vol2grid
             write(12, *) i, sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1)), &
                             maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
         endif
 
-        if (verbose .and. (i == 2)) then
+        if (l_verbose .and. (i == 2)) then
             open(unit=1236, file='two_iter_laplace_corr.asc', status='replace')
             write(1236, *) '# x, y volume B11, B22'
             do n = 1, n_parcels
@@ -125,7 +125,7 @@ program test_laplace_correction
         endif
     enddo
 
-    if (verbose) then
+    if (l_verbose) then
         close(12)
     endif
 

--- a/unit-tests/2d/test_parcel_correction.f90
+++ b/unit-tests/2d/test_parcel_correction.f90
@@ -91,13 +91,13 @@ program test_parcel_correction
 
     init_error = sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1))
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=12, file='test_parcel_correction.asc', status='replace')
         write(12,*) '# iteration, average error, max absolute error'
         write(12,*) 0, init_error, maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
     endif
 
-    if (verbose) then
+    if (l_verbose) then
         open(unit=1235, file='initial_parcel_corr.asc', status='replace')
         write(1235, *) '# x, y volume B11, B22'
         do n = 1, n_parcels
@@ -112,13 +112,13 @@ program test_parcel_correction
         call apply_laplace
         call vol2grid
         call apply_gradient(1.80d0,0.5d0)
-        if (verbose) then
+        if (l_verbose) then
             call vol2grid
             write(12, *) i, sum(abs(volg(0:nz, 0:nx-1) / vcell - one)) / (nx * (nz+1)), &
                             maxval(abs(volg(0:nz, 0:nx-1) / vcell - one))
         endif
 
-        if (verbose .and. (i == 2)) then
+        if (l_verbose .and. (i == 2)) then
             open(unit=1236, file='two_iter_parcel_corr.asc', status='replace')
             write(1236, *) '# x, y volume B11, B22'
             do n = 1, n_parcels
@@ -129,7 +129,7 @@ program test_parcel_correction
 
     enddo
 
-    if (verbose) then
+    if (l_verbose) then
         close(12)
     endif
 

--- a/unit-tests/3d/test_laplace_correction_3d.f90
+++ b/unit-tests/3d/test_laplace_correction_3d.f90
@@ -8,13 +8,14 @@
 program test_laplace_correction_3d
     use unit_test
     use options, only : parcel
-    use constants, only : pi, one, zero, f14, f23, f32, two, four, f12
+    use constants, only : pi, one, zero, f14, f23, f32, two, four, f12, f18
     use parcel_container
     use parcel_correction
+    use parcel_bc
     use parcel_interpl, only : vol2grid
     use parcel_ellipsoid, only : get_abc
     use parcel_init, only : init_regular_positions
-    use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz
+    use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz, dx
     use fields, only : volg
     use timer
     implicit none
@@ -22,7 +23,7 @@ program test_laplace_correction_3d
     double precision :: final_error, init_error, val, tmp
     integer :: i, n, sk
     integer, allocatable :: seed(:)
-    double precision, parameter :: dev = 0.005d0
+    double precision :: q, m, delta
 
     call random_seed(size=sk)
     allocate(seed(1:sk))
@@ -35,38 +36,55 @@ program test_laplace_correction_3d
     call register_timer('vorticity correction', vort_corr_timer)
 
 
-    nx = 16
+    nx = 32
     ny = 32
-    nz = 64
+    nz = 32
 
     lower  = (/zero, zero, zero/)
-    extent = (/one, two, four/)
+    extent = (/one, one, one/)
 
     call update_parameters
 
     allocate(volg(-1:nz+1, 0:ny-1, 0:nx-1))
 
-    n_parcels = 27*nx*ny*nz
+    n_parcels = 8*nx*ny*nz
     call parcel_alloc(n_parcels)
 
-    parcel%n_per_cell = 27
+    parcel%n_per_cell = 8
     call init_regular_positions
+
+    ! 0 --> -delta
+    ! 1 -->  delta
+    ! y = mx + q
+    ! -delta = q
+    ! delta = m - delta --> m = 2 * delta
+    delta = f14 * dx(1)
+
+    q = - delta
+    m = two * delta
 
     ! add some deviation
     do n = 1, n_parcels
-        do i = 1, 3
-            tmp = dev
-            call random_number(val)
-            if (val < 0.5) then
-                tmp = -dev
-            endif
-            parcels%position(i, n) = parcels%position(i, n) + tmp
-        enddo
+        call random_number(val)
+
+        tmp = m * val + q
+        parcels%position(1, n) = parcels%position(1, n) + tmp
+
+        call random_number(val)
+        tmp = m * val + q
+        parcels%position(2, n) = parcels%position(2, n) + tmp
+
+        call random_number(val)
+        tmp = m * val + q
+        parcels%position(3, n) = parcels%position(3, n) + tmp
+
+        call apply_periodic_bc(parcels%position(:, n))
+        call apply_reflective_bc(parcels%position(:, n), parcels%B(:, n))
     enddo
 
     volg = zero
 
-    parcels%volume = vcell / 27.0d0
+    parcels%volume = f18 * vcell
 
     parcels%B(:, :) = zero
 
@@ -80,22 +98,27 @@ program test_laplace_correction_3d
 
     init_error = sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1))
 
-    if (verbose) then
-        write(*,*) 'test laplace correction'
-        write(*,*) 'iteration, average error, max absolute error'
-        write(*,*) 0, init_error, maxval(abs(volg(0:nz, :, :) / vcell - one))
+    if (l_verbose) then
+        open(unit=12, file='test_laplace_correction.asc', status='replace')
+        write(12,*) '# iteration, average error, max absolute error'
+        write(12,*) 0, init_error, maxval(abs(volg(0:nz, :, :) / vcell - one))
     endif
+
 
     call init_parcel_correction
 
     do i = 1, 20
         call apply_laplace
-        if (verbose) then
+        if (l_verbose) then
             call vol2grid
-            write(*,*) i, sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1)), &
-                          maxval(abs(volg(0:nz, :, :) / vcell - one))
+            write(12,*) i, sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1)), &
+                           maxval(abs(volg(0:nz, :, :) / vcell - one))
         endif
     enddo
+
+    if (l_verbose) then
+        close(12)
+    endif
 
     call vol2grid
 

--- a/unit-tests/3d/test_parcel_correction_3d.f90
+++ b/unit-tests/3d/test_parcel_correction_3d.f90
@@ -8,13 +8,14 @@
 program test_parcel_correction_3d
     use unit_test
     use options, only : parcel
-    use constants, only : pi, one, zero, f14, f23, f32, two, four, f12
+    use constants, only : pi, one, zero, f14, f23, f32, two, four, f12, f18
     use parcel_container
     use parcel_correction
+    use parcel_bc
     use parcel_interpl, only : vol2grid
     use parcel_ellipsoid, only : get_abc
     use parcel_init, only : init_regular_positions
-    use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz
+    use parameters, only : lower, extent, update_parameters, vcell, nx, ny, nz, dx
     use fields, only : volg
     use timer
     implicit none
@@ -22,7 +23,7 @@ program test_parcel_correction_3d
     double precision :: final_error, init_error, val, tmp
     integer :: i, n, sk
     integer, allocatable :: seed(:)
-    double precision, parameter :: dev = 0.005d0
+    double precision :: q, m, delta
 
     call random_seed(size=sk)
     allocate(seed(1:sk))
@@ -36,38 +37,55 @@ program test_parcel_correction_3d
     call register_timer('vorticity correction', vort_corr_timer)
 
 
-    nx = 16
+    nx = 32
     ny = 32
-    nz = 64
+    nz = 32
 
     lower  = (/zero, zero, zero/)
-    extent = (/one, two, four/)
+    extent = (/one, one, one/)
 
     call update_parameters
 
     allocate(volg(-1:nz+1, 0:ny-1, 0:nx-1))
 
-    n_parcels = 27*nx*ny*nz
+    n_parcels = 8*nx*ny*nz
     call parcel_alloc(n_parcels)
 
-    parcel%n_per_cell = 27
+    parcel%n_per_cell = 8
     call init_regular_positions
+
+    ! 0 --> -delta
+    ! 1 -->  delta
+    ! y = mx + q
+    ! -delta = q
+    ! delta = m - delta --> m = 2 * delta
+    delta = f14 * dx(1)
+
+    q = - delta
+    m = two * delta
 
     ! add some deviation
     do n = 1, n_parcels
-        do i = 1, 3
-            tmp = dev
-            call random_number(val)
-            if (val < 0.5) then
-                tmp = -dev
-            endif
-            parcels%position(i, n) = parcels%position(i, n) + tmp
-        enddo
+        call random_number(val)
+
+        tmp = m * val + q
+        parcels%position(1, n) = parcels%position(1, n) + tmp
+
+        call random_number(val)
+        tmp = m * val + q
+        parcels%position(2, n) = parcels%position(2, n) + tmp
+
+        call random_number(val)
+        tmp = m * val + q
+        parcels%position(3, n) = parcels%position(3, n) + tmp
+
+        call apply_periodic_bc(parcels%position(:, n))
+        call apply_reflective_bc(parcels%position(:, n), parcels%B(:, n))
     enddo
 
     volg = zero
 
-    parcels%volume = vcell / 27.0d0
+    parcels%volume = f18 * vcell
 
     parcels%B(:, :) = zero
 
@@ -81,10 +99,10 @@ program test_parcel_correction_3d
 
     init_error = sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1))
 
-    if (verbose) then
-        write(*,*) 'test parcel correction'
-        write(*,*) 'iteration, average error, max absolute error'
-        write(*,*) 0, init_error, maxval(abs(volg(0:nz, :, :) / vcell - one))
+    if (l_verbose) then
+        open(unit=12, file='test_parcel_correction.asc', status='replace')
+        write(12,*) '# iteration, average error, max absolute error'
+        write(12,*) 0, init_error, maxval(abs(volg(0:nz, :, :) / vcell - one))
     endif
 
     call init_parcel_correction
@@ -93,12 +111,16 @@ program test_parcel_correction_3d
         call apply_laplace
         call vol2grid
         call apply_gradient(1.80d0,0.5d0)
-        if (verbose) then
+        if (l_verbose) then
             call vol2grid
-            write(*,*) i, sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1)), &
-                          maxval(abs(volg(0:nz, :, :) / vcell - one))
+            write(12,*) i, sum(abs(volg(0:nz, :, :) / vcell - one)) / (nx * ny * (nz+1)), &
+                           maxval(abs(volg(0:nz, :, :) / vcell - one))
         endif
     enddo
+
+    if (l_verbose) then
+        close(12)
+    endif
 
     call vol2grid
 

--- a/unit-tests/unit_test.f90
+++ b/unit-tests/unit_test.f90
@@ -4,7 +4,10 @@ module unit_test
     ! abolute tolerance
     double precision, parameter :: atol_m = dble(1.0e-15)
 
+    logical :: l_verbose = .false.
+
     private :: atol_m
+
 
     contains
 
@@ -51,7 +54,6 @@ module unit_test
             integer           :: i
             character(len=32) :: arg
             character(len=32) :: testname
-            logical           :: verbose = .false.
 
             testname = ''
             i = 0
@@ -62,12 +64,12 @@ module unit_test
                 elseif (len_trim(arg) == 0) then
                     exit
                 elseif (arg == '--verbose') then
-                    verbose = .true.
+                    l_verbose = .true.
                 endif
                 i = i+1
             end do
 
-            if (verbose) then
+            if (l_verbose) then
                 print *, 'Running ', trim(testname),' verbosely'
             endif
         end subroutine parse_command_line


### PR DESCRIPTION
This pull request
* fixes the verbose mode in the parcel correction unit tests
* fixes a comment in inversion.f90
* updates the initialisation of the parcels in the 3D parcel correction unit tests