### PR TITLE
Initialise parcels like grid2par

### DIFF
--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -30,8 +30,7 @@ program epic3d
     use ls_rk4, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk4_step, rk4_timer
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
-                    , setup_parcels                              &
-                    , setup_fields
+                    , setup_fields_and_parcels
     use parameters, only : max_num_parcels
     implicit none
 
@@ -83,9 +82,7 @@ program epic3d
             ! read domain dimensions
             call setup_domain_and_parameters
 
-            call setup_fields
-
-            call setup_parcels
+            call setup_fields_and_parcels
 
             call ls_rk4_alloc(max_num_parcels)
 

--- a/src/3d/epic3d.f90
+++ b/src/3d/epic3d.f90
@@ -30,7 +30,8 @@ program epic3d
     use ls_rk4, only : ls_rk4_alloc, ls_rk4_dealloc, ls_rk4_step, rk4_timer
     use utils, only : write_last_step, setup_output_files        &
                     , setup_restart, setup_domain_and_parameters &
-                    , setup_parcels
+                    , setup_parcels                              &
+                    , setup_fields
     use parameters, only : max_num_parcels
     implicit none
 
@@ -82,6 +83,8 @@ program epic3d
             ! read domain dimensions
             call setup_domain_and_parameters
 
+            call setup_fields
+
             call setup_parcels
 
             call ls_rk4_alloc(max_num_parcels)
@@ -89,8 +92,6 @@ program epic3d
             call init_inversion
 
             call init_parcel_correction
-
-            call field_default
 
             call setup_output_files
 

--- a/src/3d/fields/field_netcdf.f90
+++ b/src/3d/fields/field_netcdf.f90
@@ -400,42 +400,44 @@ module field_netcdf
         subroutine read_netcdf_field_fields(fname, step)
             character(*), intent(in) :: fname
             integer,      intent(in) :: step
-            integer                  :: n_steps, ncid, start(4), cnt(4)
+            integer                  :: n_steps, lid, start(4), cnt(4), st
 
-            call open_netcdf_file(fname, NF90_NOWRITE, ncid)
+            call open_netcdf_file(fname, NF90_NOWRITE, lid)
 
-            call get_num_steps(ncid, n_steps)
+            call get_num_steps(lid, n_steps)
 
-            if ((step < 1) .or. (step > n_steps)) then
+            if (step == -1) then
+                st = n_steps
+            else if ((step == 0) .or. (step > n_steps)) then
                 print *, "Step number out of bounds."
                 error stop
             endif
 
-            cnt  =  (/ nx, ny, nz+1, 1    /)
-            start = (/ 1,  1,  1,    step /)
+            cnt  =  (/ nx, ny, nz+1, 1  /)
+            start = (/ 1,  1,  1,    st /)
 
-            if (has_dataset(ncid, 'x_vorticity')) then
-                call read_netcdf_dataset(ncid, 'x_vorticity', vortg(0:nz, :, :, 1), start, cnt)
+            if (has_dataset(lid, 'x_vorticity')) then
+                call read_netcdf_dataset(lid, 'x_vorticity', vortg(0:nz, :, :, 1), start, cnt)
             endif
 
-            if (has_dataset(ncid, 'y_vorticity')) then
-                call read_netcdf_dataset(ncid, 'y_vorticity', vortg(0:nz, :, :, 2), start, cnt)
+            if (has_dataset(lid, 'y_vorticity')) then
+                call read_netcdf_dataset(lid, 'y_vorticity', vortg(0:nz, :, :, 2), start, cnt)
             endif
 
-            if (has_dataset(ncid, 'z_vorticity')) then
-                call read_netcdf_dataset(ncid, 'z_vorticity', vortg(0:nz, :, :, 3), start, cnt)
+            if (has_dataset(lid, 'z_vorticity')) then
+                call read_netcdf_dataset(lid, 'z_vorticity', vortg(0:nz, :, :, 3), start, cnt)
             endif
 
-            if (has_dataset(ncid, 'buoyancy')) then
-                call read_netcdf_dataset(ncid, 'buoyancy', tbuoyg(0:nz, :, :), start, cnt)
+            if (has_dataset(lid, 'buoyancy')) then
+                call read_netcdf_dataset(lid, 'buoyancy', tbuoyg(0:nz, :, :), start, cnt)
             endif
 
 #ifndef ENABLE_DRY_MODE
-            if (has_dataset(ncid, 'humidity')) then
-                call read_netcdf_dataset(ncid, 'humidity', humg(0:nz, :, :), start, cnt)
+            if (has_dataset(lid, 'humidity')) then
+                call read_netcdf_dataset(lid, 'humidity', humg(0:nz, :, :), start, cnt)
             endif
 #endif
-            call close_netcdf_file(ncid)
+            call close_netcdf_file(lid)
 
         end subroutine read_netcdf_field_fields
 

--- a/src/3d/fields/field_netcdf.f90
+++ b/src/3d/fields/field_netcdf.f90
@@ -406,9 +406,11 @@ module field_netcdf
 
             call get_num_steps(lid, n_steps)
 
-            if (step == -1) then
+            st = step
+
+            if (st == -1) then
                 st = n_steps
-            else if ((step == 0) .or. (step > n_steps)) then
+            else if ((st == 0) .or. (st > n_steps)) then
                 print *, "Step number out of bounds."
                 error stop
             endif

--- a/src/3d/fields/field_netcdf.f90
+++ b/src/3d/fields/field_netcdf.f90
@@ -303,7 +303,7 @@ module field_netcdf
 
 #ifndef ENABLE_DRY_MODE
             call get_var_id(ncid, 'dry_buoyancy', dbuoy_id)
-            
+
             call get_var_id(ncid, 'humidity', hum_id)
 
             call get_var_id(ncid, 'liquid_water_content', lbuoy_id)
@@ -395,5 +395,48 @@ module field_netcdf
             call stop_timer(field_io_timer)
 
         end subroutine write_netcdf_fields
+
+
+        subroutine read_netcdf_field_fields(fname, step)
+            character(*), intent(in) :: fname
+            integer,      intent(in) :: step
+            integer                  :: n_steps, ncid, start(4), cnt(4)
+
+            call open_netcdf_file(fname, NF90_NOWRITE, ncid)
+
+            call get_num_steps(ncid, n_steps)
+
+            if ((step < 1) .or. (step > n_steps)) then
+                print *, "Step number out of bounds."
+                error stop
+            endif
+
+            cnt  =  (/ nx, ny, nz+1, 1    /)
+            start = (/ 1,  1,  1,    step /)
+
+            if (has_dataset(ncid, 'x_vorticity')) then
+                call read_netcdf_dataset(ncid, 'x_vorticity', vortg(0:nz, :, :, 1), start, cnt)
+            endif
+
+            if (has_dataset(ncid, 'y_vorticity')) then
+                call read_netcdf_dataset(ncid, 'y_vorticity', vortg(0:nz, :, :, 2), start, cnt)
+            endif
+
+            if (has_dataset(ncid, 'z_vorticity')) then
+                call read_netcdf_dataset(ncid, 'z_vorticity', vortg(0:nz, :, :, 3), start, cnt)
+            endif
+
+            if (has_dataset(ncid, 'buoyancy')) then
+                call read_netcdf_dataset(ncid, 'buoyancy', tbuoyg(0:nz, :, :), start, cnt)
+            endif
+
+#ifndef ENABLE_DRY_MODE
+            if (has_dataset(ncid, 'humidity')) then
+                call read_netcdf_dataset(ncid, 'humidity', humg(0:nz, :, :), start, cnt)
+            endif
+#endif
+            call close_netcdf_file(ncid)
+
+        end subroutine read_netcdf_field_fields
 
 end module field_netcdf

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -3,9 +3,9 @@
 ! =============================================================================
 module parcel_init
     use options, only : parcel, output, verbose, field_tol
-    use constants, only : zero, two, one, f12, f13, f23
-    use parcel_container, only : parcels, n_parcels
-    use parcel_ellipsoid, only : get_abc, get_eigenvalues
+    use constants, only : zero, two, one, f12, f13, f23, f14
+    use parcel_container, only : parcels, n_parcels, parcel_alloc
+    use parcel_ellipsoid, only : get_abc, get_eigenvalues, get_ellipsoid_points
     use parcel_split_mod, only : parcel_split
     use parcel_interpl, only : trilinear, ngp
     use parameters, only : dx, vcell, ncell,            &
@@ -13,40 +13,50 @@ module parcel_init
                            max_num_parcels
     use timer, only : start_timer, stop_timer
     use omp_lib
+    use fields
     implicit none
 
     integer :: init_timer
 
-    double precision, allocatable :: weights(:, :), apar(:)
-    integer, allocatable :: is(:, :), js(:, :), ks(:, :)
+!     double precision, allocatable :: weights(:, :), apar(:)
+!     integer, allocatable :: is(:, :), js(:, :), ks(:, :)
 
-    private :: weights, apar, is, js, ks
+    integer :: is(ngp), js(ngp), ks(ngp)
+
+    ! interpolation weights
+    double precision :: weights(ngp)
+
+    private :: weights, is, js, ks
+
+!     private :: weights, apar, is, js, ks
 
 
-    private :: init_refine,                 &
-               init_from_grids,             &
-               alloc_and_precompute,        &
-               dealloc
+    private :: init_refine!,                 &
+!                init_from_grids,             &
+!                alloc_and_precompute,        &
+!                dealloc
 
     contains
 
-        ! This subroutine is only used in the unit test
-        ! "test_parcel_init"
-        subroutine unit_test_parcel_init_alloc
-            call alloc_and_precompute
-        end subroutine unit_test_parcel_init_alloc
+!         ! This subroutine is only used in the unit test
+!         ! "test_parcel_init"
+!         subroutine unit_test_parcel_init_alloc
+!             call alloc_and_precompute
+!         end subroutine unit_test_parcel_init_alloc
 
 
         ! Set default values for parcel attributes
         ! Attention: This subroutine assumes that the parcel
         !            container is already allocated!
-        subroutine init_parcels(fname, tol)
-            character(*),     intent(in) :: fname
-            double precision, intent(in) :: tol
+        subroutine init_parcels!(fname, tol)
+!             character(*),     intent(in) :: fname
+!             double precision, intent(in) :: tol
             double precision             :: lam, l23
             integer                      :: n
 
             call start_timer(init_timer)
+
+            call parcel_alloc(max_num_parcels)
 
             ! set the number of parcels (see parcels.f90)
             ! we use "n_per_cell" parcels per grid cell
@@ -105,11 +115,45 @@ module parcel_init
             !$omp end do
             !$omp end parallel
 
-            call init_from_grids(fname, tol)
+            call new_init
+
+!             call init_from_grids(fname, tol)
 
             call stop_timer(init_timer)
 
         end subroutine init_parcels
+
+        subroutine new_init
+            double precision :: points(3, 4)
+            integer          :: n, l, p
+
+            !$omp parallel default(shared)
+            !$omp do private(n, l, p, points, is, js, ks, weights)
+            do n = 1, n_parcels
+
+                points = get_ellipsoid_points(parcels%position(:, n), &
+                                              parcels%volume(n), parcels%B(:, n), n)
+
+                do p = 1, 4
+!                     ! ensure point is within the domain
+!                     call apply_periodic_bc(points(:, p))
+
+                    ! get interpolation weights and mesh indices
+                    call trilinear(points(:, p), is, js, ks, weights)
+
+                    ! loop over grid points which are part of the interpolation
+                    do l = 1, ngp
+                        parcels%vorticity(:, n) = f14 * weights(l) * vortg(ks(l), js(l), is(l), :)
+                        parcels%buoyancy(n) = f14 * weights(l) * tbuoyg(ks(l), js(l), is(l))
+#ifndef ENABLE_DRY_MODE
+                        parcels%humidity(n) = f14 * weights/l) * humg(ks(l), js(l), is(l))
+#endif
+                    enddo
+                enddo
+            enddo
+            !$omp end do
+            !$omp end parallel
+        end subroutine new_init
 
 
         ! Position parcels regularly in the domain.
@@ -165,229 +209,229 @@ module parcel_init
         end subroutine init_refine
 
 
-        ! Precompute weights, indices of trilinear
-        ! interpolation and "apar"
-        subroutine alloc_and_precompute
-            double precision, allocatable :: resi(:, :, :)
-            double precision              :: rsum
-            integer                       :: l, n
+!         ! Precompute weights, indices of trilinear
+!         ! interpolation and "apar"
+!         subroutine alloc_and_precompute
+!             double precision, allocatable :: resi(:, :, :)
+!             double precision              :: rsum
+!             integer                       :: l, n
+!
+!             allocate(resi(0:nz, 0:ny-1, 0:nx-1))
+!             allocate(apar(n_parcels))
+!             allocate(weights(ngp, n_parcels))
+!             allocate(is(ngp, n_parcels))
+!             allocate(js(ngp, n_parcels))
+!             allocate(ks(ngp, n_parcels))
+!
+!             ! Compute mean parcel density:
+!             resi = zero
+!
+!             !$omp parallel do default(shared) private(l, n) reduction(+:resi)
+!             do n = 1, n_parcels
+!                 ! get interpolation weights and mesh indices
+!                 call trilinear(parcels%position(:, n), is(:, n), js(:, n), ks(:, n), weights(:, n))
+!
+!                 do l = 1, ngp
+!                     ! catch if in halo
+!                     if ((ks(l, n) < 0) .or. (ks(l, n) > nz)) then
+!                         print *, "Error: Tries to access undefined halo grid point."
+!                         stop
+!                     endif
+!                     resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) + weights(l, n)
+!                 enddo
+!             enddo
+!             !$omp end parallel do
+!
+!             !Double edge values at iz = 0 and nz:
+!             resi(0,  :, :) = two * resi(0,  :, :)
+!             resi(nz, :, :) = two * resi(nz, :, :)
+!
+!             ! Determine local inverse density of parcels (apar)
+!             !$omp parallel do default(shared) private(l, n, rsum)
+!             do n = 1, n_parcels
+!                 rsum = zero
+!                 do l = 1, ngp
+!                     rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
+!                 enddo
+!                 apar(n) = one / rsum
+!             enddo
+!             !$omp end parallel do
+!
+!             deallocate(resi)
+!
+!         end subroutine alloc_and_precompute
 
-            allocate(resi(0:nz, 0:ny-1, 0:nx-1))
-            allocate(apar(n_parcels))
-            allocate(weights(ngp, n_parcels))
-            allocate(is(ngp, n_parcels))
-            allocate(js(ngp, n_parcels))
-            allocate(ks(ngp, n_parcels))
+!         subroutine dealloc
+!             deallocate(apar)
+!             deallocate(weights)
+!             deallocate(is)
+!             deallocate(js)
+!             deallocate(ks)
+!         end subroutine dealloc
 
-            ! Compute mean parcel density:
-            resi = zero
-
-            !$omp parallel do default(shared) private(l, n) reduction(+:resi)
-            do n = 1, n_parcels
-                ! get interpolation weights and mesh indices
-                call trilinear(parcels%position(:, n), is(:, n), js(:, n), ks(:, n), weights(:, n))
-
-                do l = 1, ngp
-                    ! catch if in halo
-                    if ((ks(l, n) < 0) .or. (ks(l, n) > nz)) then
-                        print *, "Error: Tries to access undefined halo grid point."
-                        stop
-                    endif
-                    resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) + weights(l, n)
-                enddo
-            enddo
-            !$omp end parallel do
-
-            !Double edge values at iz = 0 and nz:
-            resi(0,  :, :) = two * resi(0,  :, :)
-            resi(nz, :, :) = two * resi(nz, :, :)
-
-            ! Determine local inverse density of parcels (apar)
-            !$omp parallel do default(shared) private(l, n, rsum)
-            do n = 1, n_parcels
-                rsum = zero
-                do l = 1, ngp
-                    rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-                enddo
-                apar(n) = one / rsum
-            enddo
-            !$omp end parallel do
-
-            deallocate(resi)
-
-        end subroutine alloc_and_precompute
-
-        subroutine dealloc
-            deallocate(apar)
-            deallocate(weights)
-            deallocate(is)
-            deallocate(js)
-            deallocate(ks)
-        end subroutine dealloc
-
-        ! Initialise parcel attributes from gridded quantities.
-        ! Attention: This subroutine currently only supports
-        !            vorticity and buoyancy fields.
-        subroutine init_from_grids(ncfname, tol)
-            use netcdf_reader
-            character(*),     intent(in)  :: ncfname
-            double precision, intent(in)  :: tol
-            double precision              :: buffer(-1:nz+1, 0:ny-1, 0:nx-1)
-            integer                       :: ncid
-            integer                       :: n_steps, start(4), cnt(4)
-
-            call alloc_and_precompute
-
-            call open_netcdf_file(ncfname, NF90_NOWRITE, ncid)
-
-            call get_num_steps(ncid, n_steps)
-
-            cnt  =  (/ nx, ny, nz+1, 1       /)
-            start = (/ 1,  1,  1,    n_steps /)
-
-            if (has_dataset(ncid, 'x_vorticity')) then
-                buffer = zero
-                call read_netcdf_dataset(ncid, 'x_vorticity', buffer(0:nz, :, :), &
-                                         start=start, cnt=cnt)
-                call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(1, :))
-            endif
-
-            if (has_dataset(ncid, 'y_vorticity')) then
-                buffer = zero
-                call read_netcdf_dataset(ncid, 'y_vorticity', buffer(0:nz, :, :), &
-                                         start=start, cnt=cnt)
-                call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(2, :))
-            endif
-
-            if (has_dataset(ncid, 'z_vorticity')) then
-                buffer = zero
-                call read_netcdf_dataset(ncid, 'z_vorticity', buffer(0:nz, :, :), &
-                                         start=start, cnt=cnt)
-                call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(3, :))
-            endif
-
-            if (has_dataset(ncid, 'buoyancy')) then
-                buffer = zero
-                call read_netcdf_dataset(ncid, 'buoyancy', buffer(0:nz, :, :), &
-                                         start=start, cnt=cnt)
-                call gen_parcel_scalar_attr(buffer, tol, parcels%buoyancy)
-            endif
-
-#ifndef ENABLE_DRY_MODE
-            if (has_dataset(ncid, 'humidity')) then
-                buffer = zero
-                call read_netcdf_dataset(ncid, 'humidity', buffer(0:nz, :, :), &
-                                         start=start, cnt=cnt)
-                call gen_parcel_scalar_attr(buffer, tol, parcels%humidity)
-            endif
-#endif
-            call close_netcdf_file(ncid)
-
-            call dealloc
-
-        end subroutine init_from_grids
-
-        ! Generates the parcel attribute "par" from the field values provided
-        ! in "field" (see Fontane & Dritschel, J. Comput. Phys. 2009, section 2.2)
-        subroutine gen_parcel_scalar_attr(field, tol, par)
-            double precision, intent(in)  :: field(-1:nz+1, 0:ny-1, 0:nx-1)
-            double precision, intent(in)  :: tol
-            double precision, intent(out) :: par(:)
-            double precision :: resi(0:nz, 0:ny-1, 0:nx-1)
-            double precision :: rms, rtol, rerr, rsum, fsum, avg_field
-            integer          :: l, n
-
-#ifdef ENABLE_VERBOSE
-                if (verbose) then
-                    print *, 'Generate parcel attribute'
-                endif
-#endif
-
-            ! Compute mean field value:
-            ! (divide by ncell since lower and upper edge weights are halved)
-            avg_field = (f12 * sum(field(0, :, :) + field(nz, :, :)) &
-                             + sum(field(1:nz-1, :, :))) / dble(ncell)
-
-            resi(0:nz, :, :) = (field(0:nz, :, :) - avg_field) ** 2
-
-            rms = dsqrt((f12 * sum(resi(0, :, :) + resi(nz, :, :)) &
-                             + sum(resi(1:nz-1, :, :))) / dble(ncell))
-
-
-            if (rms == zero) then
-                !$omp parallel default(shared)
-                !$omp do private(n)
-                do n = 1, n_parcels
-                    ! assign mean value
-                    par(n) = avg_field
-                enddo
-                !$omp end do
-                !$omp end parallel
-                return
-            endif
-
-            ! Maximum error permitted below in gridded residue:
-            rtol = rms * tol
-
-            ! Initialise (volume-weighted) parcel attribute with a guess
-            !$omp parallel do default(shared) private(l, n, fsum)
-            do n = 1, n_parcels
-                fsum = zero
-                do l = 1, ngp
-                    fsum = fsum + field(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-                enddo
-                par(n) = apar(n) * fsum
-            enddo
-            !$omp end parallel do
-
-            ! Iteratively compute a residual and update (volume-weighted) attribute:
-            rerr = one
-
-            do while (rerr .gt. rtol)
-                !Compute residual:
-                resi = zero
-                do n = 1, n_parcels
-                    do l = 1, ngp
-                        resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) &
-                                                           + weights(l, n) * par(n)
-                    enddo
-                enddo
-
-                resi(0, :, :)    = two * resi(0, :, :)
-                resi(nz, :, :)   = two * resi(nz, :, :)
-                resi(0:nz, :, :) = field(0:nz, :, :) - resi(0:nz, :, :)
-
-                !Update (volume-weighted) attribute:
-                !$omp parallel do default(shared) private(n, rsum, l)
-                do n = 1, n_parcels
-                    rsum = zero
-                    do l = 1, ngp
-                        rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-                    enddo
-                    par(n) = par(n) + apar(n) * rsum
-                enddo
-                !$omp end parallel do
-
-                !Compute maximum error:
-                rerr = maxval(dabs(resi))
-
-#ifdef ENABLE_VERBOSE
-                if (verbose) then
-                    print *, ' Max abs error = ', rerr
-                endif
-#endif
-            enddo
-
-            !Finally divide by parcel volume to define attribute:
-            ! (multiply with vcell since algorithm is designed for volume fractions)
-            !$omp parallel default(shared)
-            !$omp do private(n)
-            do n = 1, n_parcels
-                par(n) = vcell * par(n) / parcels%volume(n)
-            enddo
-            !$omp end do
-            !$omp end parallel
-
-        end subroutine gen_parcel_scalar_attr
+!         ! Initialise parcel attributes from gridded quantities.
+!         ! Attention: This subroutine currently only supports
+!         !            vorticity and buoyancy fields.
+!         subroutine init_from_grids(ncfname, tol)
+!             use netcdf_reader
+!             character(*),     intent(in)  :: ncfname
+!             double precision, intent(in)  :: tol
+!             double precision              :: buffer(-1:nz+1, 0:ny-1, 0:nx-1)
+!             integer                       :: ncid
+!             integer                       :: n_steps, start(4), cnt(4)
+!
+!             call alloc_and_precompute
+!
+!             call open_netcdf_file(ncfname, NF90_NOWRITE, ncid)
+!
+!             call get_num_steps(ncid, n_steps)
+!
+!             cnt  =  (/ nx, ny, nz+1, 1       /)
+!             start = (/ 1,  1,  1,    n_steps /)
+!
+!             if (has_dataset(ncid, 'x_vorticity')) then
+!                 buffer = zero
+!                 call read_netcdf_dataset(ncid, 'x_vorticity', buffer(0:nz, :, :), &
+!                                          start=start, cnt=cnt)
+!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(1, :))
+!             endif
+!
+!             if (has_dataset(ncid, 'y_vorticity')) then
+!                 buffer = zero
+!                 call read_netcdf_dataset(ncid, 'y_vorticity', buffer(0:nz, :, :), &
+!                                          start=start, cnt=cnt)
+!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(2, :))
+!             endif
+!
+!             if (has_dataset(ncid, 'z_vorticity')) then
+!                 buffer = zero
+!                 call read_netcdf_dataset(ncid, 'z_vorticity', buffer(0:nz, :, :), &
+!                                          start=start, cnt=cnt)
+!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(3, :))
+!             endif
+!
+!             if (has_dataset(ncid, 'buoyancy')) then
+!                 buffer = zero
+!                 call read_netcdf_dataset(ncid, 'buoyancy', buffer(0:nz, :, :), &
+!                                          start=start, cnt=cnt)
+!                 call gen_parcel_scalar_attr(buffer, tol, parcels%buoyancy)
+!             endif
+!
+! #ifndef ENABLE_DRY_MODE
+!             if (has_dataset(ncid, 'humidity')) then
+!                 buffer = zero
+!                 call read_netcdf_dataset(ncid, 'humidity', buffer(0:nz, :, :), &
+!                                          start=start, cnt=cnt)
+!                 call gen_parcel_scalar_attr(buffer, tol, parcels%humidity)
+!             endif
+! #endif
+!             call close_netcdf_file(ncid)
+!
+!             call dealloc
+!
+!         end subroutine init_from_grids
+!
+!         ! Generates the parcel attribute "par" from the field values provided
+!         ! in "field" (see Fontane & Dritschel, J. Comput. Phys. 2009, section 2.2)
+!         subroutine gen_parcel_scalar_attr(field, tol, par)
+!             double precision, intent(in)  :: field(-1:nz+1, 0:ny-1, 0:nx-1)
+!             double precision, intent(in)  :: tol
+!             double precision, intent(out) :: par(:)
+!             double precision :: resi(0:nz, 0:ny-1, 0:nx-1)
+!             double precision :: rms, rtol, rerr, rsum, fsum, avg_field
+!             integer          :: l, n
+!
+! #ifdef ENABLE_VERBOSE
+!                 if (verbose) then
+!                     print *, 'Generate parcel attribute'
+!                 endif
+! #endif
+!
+!             ! Compute mean field value:
+!             ! (divide by ncell since lower and upper edge weights are halved)
+!             avg_field = (f12 * sum(field(0, :, :) + field(nz, :, :)) &
+!                              + sum(field(1:nz-1, :, :))) / dble(ncell)
+!
+!             resi(0:nz, :, :) = (field(0:nz, :, :) - avg_field) ** 2
+!
+!             rms = dsqrt((f12 * sum(resi(0, :, :) + resi(nz, :, :)) &
+!                              + sum(resi(1:nz-1, :, :))) / dble(ncell))
+!
+!
+!             if (rms == zero) then
+!                 !$omp parallel default(shared)
+!                 !$omp do private(n)
+!                 do n = 1, n_parcels
+!                     ! assign mean value
+!                     par(n) = avg_field
+!                 enddo
+!                 !$omp end do
+!                 !$omp end parallel
+!                 return
+!             endif
+!
+!             ! Maximum error permitted below in gridded residue:
+!             rtol = rms * tol
+!
+!             ! Initialise (volume-weighted) parcel attribute with a guess
+!             !$omp parallel do default(shared) private(l, n, fsum)
+!             do n = 1, n_parcels
+!                 fsum = zero
+!                 do l = 1, ngp
+!                     fsum = fsum + field(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
+!                 enddo
+!                 par(n) = apar(n) * fsum
+!             enddo
+!             !$omp end parallel do
+!
+!             ! Iteratively compute a residual and update (volume-weighted) attribute:
+!             rerr = one
+!
+!             do while (rerr .gt. rtol)
+!                 !Compute residual:
+!                 resi = zero
+!                 do n = 1, n_parcels
+!                     do l = 1, ngp
+!                         resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) &
+!                                                            + weights(l, n) * par(n)
+!                     enddo
+!                 enddo
+!
+!                 resi(0, :, :)    = two * resi(0, :, :)
+!                 resi(nz, :, :)   = two * resi(nz, :, :)
+!                 resi(0:nz, :, :) = field(0:nz, :, :) - resi(0:nz, :, :)
+!
+!                 !Update (volume-weighted) attribute:
+!                 !$omp parallel do default(shared) private(n, rsum, l)
+!                 do n = 1, n_parcels
+!                     rsum = zero
+!                     do l = 1, ngp
+!                         rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
+!                     enddo
+!                     par(n) = par(n) + apar(n) * rsum
+!                 enddo
+!                 !$omp end parallel do
+!
+!                 !Compute maximum error:
+!                 rerr = maxval(dabs(resi))
+!
+! #ifdef ENABLE_VERBOSE
+!                 if (verbose) then
+!                     print *, ' Max abs error = ', rerr
+!                 endif
+! #endif
+!             enddo
+!
+!             !Finally divide by parcel volume to define attribute:
+!             ! (multiply with vcell since algorithm is designed for volume fractions)
+!             !$omp parallel default(shared)
+!             !$omp do private(n)
+!             do n = 1, n_parcels
+!                 par(n) = vcell * par(n) / parcels%volume(n)
+!             enddo
+!             !$omp end do
+!             !$omp end parallel
+!
+!         end subroutine gen_parcel_scalar_attr
 
 end module parcel_init

--- a/src/3d/parcels/parcel_init.f90
+++ b/src/3d/parcels/parcel_init.f90
@@ -18,9 +18,6 @@ module parcel_init
 
     integer :: init_timer
 
-!     double precision, allocatable :: weights(:, :), apar(:)
-!     integer, allocatable :: is(:, :), js(:, :), ks(:, :)
-
     integer :: is(ngp), js(ngp), ks(ngp)
 
     ! interpolation weights
@@ -28,29 +25,13 @@ module parcel_init
 
     private :: weights, is, js, ks
 
-!     private :: weights, apar, is, js, ks
-
-
-    private :: init_refine!,                 &
-!                init_from_grids,             &
-!                alloc_and_precompute,        &
-!                dealloc
+    private :: init_refine, init_from_grids
 
     contains
 
-!         ! This subroutine is only used in the unit test
-!         ! "test_parcel_init"
-!         subroutine unit_test_parcel_init_alloc
-!             call alloc_and_precompute
-!         end subroutine unit_test_parcel_init_alloc
-
-
-        ! Set default values for parcel attributes
-        ! Attention: This subroutine assumes that the parcel
-        !            container is already allocated!
-        subroutine init_parcels!(fname, tol)
-!             character(*),     intent(in) :: fname
-!             double precision, intent(in) :: tol
+        ! Allocate parcel container and sets values for parcel attributes
+        ! using gridded data.
+        subroutine init_parcels
             double precision             :: lam, l23
             integer                      :: n
 
@@ -103,57 +84,11 @@ module parcel_init
 
             call init_refine(lam)
 
-            !$omp parallel default(shared)
-            !$omp do private(n)
-            do n = 1, n_parcels
-                parcels%vorticity(:, n) = zero
-                parcels%buoyancy(n) = zero
-#ifndef ENABLE_DRY_MODE
-                parcels%humidity(n) = zero
-#endif
-            enddo
-            !$omp end do
-            !$omp end parallel
-
-            call new_init
-
-!             call init_from_grids(fname, tol)
+            call init_from_grids
 
             call stop_timer(init_timer)
 
         end subroutine init_parcels
-
-        subroutine new_init
-            double precision :: points(3, 4)
-            integer          :: n, l, p
-
-            !$omp parallel default(shared)
-            !$omp do private(n, l, p, points, is, js, ks, weights)
-            do n = 1, n_parcels
-
-                points = get_ellipsoid_points(parcels%position(:, n), &
-                                              parcels%volume(n), parcels%B(:, n), n)
-
-                do p = 1, 4
-!                     ! ensure point is within the domain
-!                     call apply_periodic_bc(points(:, p))
-
-                    ! get interpolation weights and mesh indices
-                    call trilinear(points(:, p), is, js, ks, weights)
-
-                    ! loop over grid points which are part of the interpolation
-                    do l = 1, ngp
-                        parcels%vorticity(:, n) = f14 * weights(l) * vortg(ks(l), js(l), is(l), :)
-                        parcels%buoyancy(n) = f14 * weights(l) * tbuoyg(ks(l), js(l), is(l))
-#ifndef ENABLE_DRY_MODE
-                        parcels%humidity(n) = f14 * weights/l) * humg(ks(l), js(l), is(l))
-#endif
-                    enddo
-                enddo
-            enddo
-            !$omp end do
-            !$omp end parallel
-        end subroutine new_init
 
 
         ! Position parcels regularly in the domain.
@@ -196,6 +131,7 @@ module parcel_init
             endif
         end subroutine init_regular_positions
 
+
         subroutine init_refine(lam)
             double precision, intent(inout) :: lam
             double precision                :: evals(3) ! = (a2, b2, c2)
@@ -209,229 +145,36 @@ module parcel_init
         end subroutine init_refine
 
 
-!         ! Precompute weights, indices of trilinear
-!         ! interpolation and "apar"
-!         subroutine alloc_and_precompute
-!             double precision, allocatable :: resi(:, :, :)
-!             double precision              :: rsum
-!             integer                       :: l, n
-!
-!             allocate(resi(0:nz, 0:ny-1, 0:nx-1))
-!             allocate(apar(n_parcels))
-!             allocate(weights(ngp, n_parcels))
-!             allocate(is(ngp, n_parcels))
-!             allocate(js(ngp, n_parcels))
-!             allocate(ks(ngp, n_parcels))
-!
-!             ! Compute mean parcel density:
-!             resi = zero
-!
-!             !$omp parallel do default(shared) private(l, n) reduction(+:resi)
-!             do n = 1, n_parcels
-!                 ! get interpolation weights and mesh indices
-!                 call trilinear(parcels%position(:, n), is(:, n), js(:, n), ks(:, n), weights(:, n))
-!
-!                 do l = 1, ngp
-!                     ! catch if in halo
-!                     if ((ks(l, n) < 0) .or. (ks(l, n) > nz)) then
-!                         print *, "Error: Tries to access undefined halo grid point."
-!                         stop
-!                     endif
-!                     resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) + weights(l, n)
-!                 enddo
-!             enddo
-!             !$omp end parallel do
-!
-!             !Double edge values at iz = 0 and nz:
-!             resi(0,  :, :) = two * resi(0,  :, :)
-!             resi(nz, :, :) = two * resi(nz, :, :)
-!
-!             ! Determine local inverse density of parcels (apar)
-!             !$omp parallel do default(shared) private(l, n, rsum)
-!             do n = 1, n_parcels
-!                 rsum = zero
-!                 do l = 1, ngp
-!                     rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-!                 enddo
-!                 apar(n) = one / rsum
-!             enddo
-!             !$omp end parallel do
-!
-!             deallocate(resi)
-!
-!         end subroutine alloc_and_precompute
+        subroutine init_from_grids
+            double precision :: points(3, 4)
+            integer          :: n, l, p
 
-!         subroutine dealloc
-!             deallocate(apar)
-!             deallocate(weights)
-!             deallocate(is)
-!             deallocate(js)
-!             deallocate(ks)
-!         end subroutine dealloc
+            !$omp parallel default(shared)
+            !$omp do private(n, l, p, points, is, js, ks, weights)
+            do n = 1, n_parcels
 
-!         ! Initialise parcel attributes from gridded quantities.
-!         ! Attention: This subroutine currently only supports
-!         !            vorticity and buoyancy fields.
-!         subroutine init_from_grids(ncfname, tol)
-!             use netcdf_reader
-!             character(*),     intent(in)  :: ncfname
-!             double precision, intent(in)  :: tol
-!             double precision              :: buffer(-1:nz+1, 0:ny-1, 0:nx-1)
-!             integer                       :: ncid
-!             integer                       :: n_steps, start(4), cnt(4)
-!
-!             call alloc_and_precompute
-!
-!             call open_netcdf_file(ncfname, NF90_NOWRITE, ncid)
-!
-!             call get_num_steps(ncid, n_steps)
-!
-!             cnt  =  (/ nx, ny, nz+1, 1       /)
-!             start = (/ 1,  1,  1,    n_steps /)
-!
-!             if (has_dataset(ncid, 'x_vorticity')) then
-!                 buffer = zero
-!                 call read_netcdf_dataset(ncid, 'x_vorticity', buffer(0:nz, :, :), &
-!                                          start=start, cnt=cnt)
-!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(1, :))
-!             endif
-!
-!             if (has_dataset(ncid, 'y_vorticity')) then
-!                 buffer = zero
-!                 call read_netcdf_dataset(ncid, 'y_vorticity', buffer(0:nz, :, :), &
-!                                          start=start, cnt=cnt)
-!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(2, :))
-!             endif
-!
-!             if (has_dataset(ncid, 'z_vorticity')) then
-!                 buffer = zero
-!                 call read_netcdf_dataset(ncid, 'z_vorticity', buffer(0:nz, :, :), &
-!                                          start=start, cnt=cnt)
-!                 call gen_parcel_scalar_attr(buffer, tol, parcels%vorticity(3, :))
-!             endif
-!
-!             if (has_dataset(ncid, 'buoyancy')) then
-!                 buffer = zero
-!                 call read_netcdf_dataset(ncid, 'buoyancy', buffer(0:nz, :, :), &
-!                                          start=start, cnt=cnt)
-!                 call gen_parcel_scalar_attr(buffer, tol, parcels%buoyancy)
-!             endif
-!
-! #ifndef ENABLE_DRY_MODE
-!             if (has_dataset(ncid, 'humidity')) then
-!                 buffer = zero
-!                 call read_netcdf_dataset(ncid, 'humidity', buffer(0:nz, :, :), &
-!                                          start=start, cnt=cnt)
-!                 call gen_parcel_scalar_attr(buffer, tol, parcels%humidity)
-!             endif
-! #endif
-!             call close_netcdf_file(ncid)
-!
-!             call dealloc
-!
-!         end subroutine init_from_grids
-!
-!         ! Generates the parcel attribute "par" from the field values provided
-!         ! in "field" (see Fontane & Dritschel, J. Comput. Phys. 2009, section 2.2)
-!         subroutine gen_parcel_scalar_attr(field, tol, par)
-!             double precision, intent(in)  :: field(-1:nz+1, 0:ny-1, 0:nx-1)
-!             double precision, intent(in)  :: tol
-!             double precision, intent(out) :: par(:)
-!             double precision :: resi(0:nz, 0:ny-1, 0:nx-1)
-!             double precision :: rms, rtol, rerr, rsum, fsum, avg_field
-!             integer          :: l, n
-!
-! #ifdef ENABLE_VERBOSE
-!                 if (verbose) then
-!                     print *, 'Generate parcel attribute'
-!                 endif
-! #endif
-!
-!             ! Compute mean field value:
-!             ! (divide by ncell since lower and upper edge weights are halved)
-!             avg_field = (f12 * sum(field(0, :, :) + field(nz, :, :)) &
-!                              + sum(field(1:nz-1, :, :))) / dble(ncell)
-!
-!             resi(0:nz, :, :) = (field(0:nz, :, :) - avg_field) ** 2
-!
-!             rms = dsqrt((f12 * sum(resi(0, :, :) + resi(nz, :, :)) &
-!                              + sum(resi(1:nz-1, :, :))) / dble(ncell))
-!
-!
-!             if (rms == zero) then
-!                 !$omp parallel default(shared)
-!                 !$omp do private(n)
-!                 do n = 1, n_parcels
-!                     ! assign mean value
-!                     par(n) = avg_field
-!                 enddo
-!                 !$omp end do
-!                 !$omp end parallel
-!                 return
-!             endif
-!
-!             ! Maximum error permitted below in gridded residue:
-!             rtol = rms * tol
-!
-!             ! Initialise (volume-weighted) parcel attribute with a guess
-!             !$omp parallel do default(shared) private(l, n, fsum)
-!             do n = 1, n_parcels
-!                 fsum = zero
-!                 do l = 1, ngp
-!                     fsum = fsum + field(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-!                 enddo
-!                 par(n) = apar(n) * fsum
-!             enddo
-!             !$omp end parallel do
-!
-!             ! Iteratively compute a residual and update (volume-weighted) attribute:
-!             rerr = one
-!
-!             do while (rerr .gt. rtol)
-!                 !Compute residual:
-!                 resi = zero
-!                 do n = 1, n_parcels
-!                     do l = 1, ngp
-!                         resi(ks(l, n), js(l, n), is(l, n)) = resi(ks(l, n), js(l, n), is(l, n)) &
-!                                                            + weights(l, n) * par(n)
-!                     enddo
-!                 enddo
-!
-!                 resi(0, :, :)    = two * resi(0, :, :)
-!                 resi(nz, :, :)   = two * resi(nz, :, :)
-!                 resi(0:nz, :, :) = field(0:nz, :, :) - resi(0:nz, :, :)
-!
-!                 !Update (volume-weighted) attribute:
-!                 !$omp parallel do default(shared) private(n, rsum, l)
-!                 do n = 1, n_parcels
-!                     rsum = zero
-!                     do l = 1, ngp
-!                         rsum = rsum + resi(ks(l, n), js(l, n), is(l, n)) * weights(l, n)
-!                     enddo
-!                     par(n) = par(n) + apar(n) * rsum
-!                 enddo
-!                 !$omp end parallel do
-!
-!                 !Compute maximum error:
-!                 rerr = maxval(dabs(resi))
-!
-! #ifdef ENABLE_VERBOSE
-!                 if (verbose) then
-!                     print *, ' Max abs error = ', rerr
-!                 endif
-! #endif
-!             enddo
-!
-!             !Finally divide by parcel volume to define attribute:
-!             ! (multiply with vcell since algorithm is designed for volume fractions)
-!             !$omp parallel default(shared)
-!             !$omp do private(n)
-!             do n = 1, n_parcels
-!                 par(n) = vcell * par(n) / parcels%volume(n)
-!             enddo
-!             !$omp end do
-!             !$omp end parallel
-!
-!         end subroutine gen_parcel_scalar_attr
+                points = get_ellipsoid_points(parcels%position(:, n), &
+                                              parcels%volume(n), parcels%B(:, n), n)
+
+                do p = 1, 4
+                    ! get interpolation weights and mesh indices
+                    call trilinear(points(:, p), is, js, ks, weights)
+
+                    ! loop over grid points which are part of the interpolation
+                    do l = 1, ngp
+                        parcels%vorticity(:, n) = parcels%vorticity(:, n) &
+                                                + f14 * weights(l) * vortg(ks(l), js(l), is(l), :)
+                        parcels%buoyancy(n) = parcels%buoyancy(n) &
+                                            + f14 * weights(l) * tbuoyg(ks(l), js(l), is(l))
+#ifndef ENABLE_DRY_MODE
+                        parcels%humidity(n) = parcels%humidity(n) &
+                                            + f14 * weights(l) * humg(ks(l), js(l), is(l))
+#endif
+                    enddo
+                enddo
+            enddo
+            !$omp end do
+            !$omp end parallel
+        end subroutine init_from_grids
 
 end module parcel_init

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -15,7 +15,7 @@ module utils
     use parcel_netcdf
     use parcel_diagnostics_netcdf
     use parcel_diagnostics
-    use parcel_container, only : n_parcels, parcel_alloc
+    use parcel_container, only : n_parcels!, parcel_alloc
     use inversion_mod, only : vor2vel, vorticity_tendency
     use parcel_interpl, only : par2grid, grid2par
     use netcdf_reader, only : get_file_type, get_num_steps, get_time, get_netcdf_box
@@ -187,27 +187,32 @@ module utils
 #endif
         end subroutine setup_domain_and_parameters
 
-        subroutine setup_parcels
+        subroutine setup_fields
             character(len=16) :: file_type
 
-            call parcel_alloc(max_num_parcels)
+            call field_default
 
             if (l_restart) then
                 call setup_restart(trim(restart_file), time%initial, file_type)
 
                 if (file_type == 'fields') then
-                    call init_parcels(restart_file, field_tol)
-                else if (file_type == 'parcels') then
-                    call read_netcdf_parcels(restart_file)
+                    ! FIXME
+!                     call init_parcels(restart_file, field_tol)
                 else
-                    print *, 'Restart file must be of type "fields" or "parcels".'
+                    print *, 'Restart file must be of type "fields".'
                     stop
                 endif
             else
                 time%initial = zero ! make sure user cannot start at arbirtrary time
-
-                call init_parcels(field_file, field_tol)
+                call read_netcdf_field_fields(field_file, 1)
             endif
+
+        end subroutine setup_fields
+
+        subroutine setup_parcels
+
+            call init_parcels
+
         end subroutine setup_parcels
 
 end module utils

--- a/src/3d/utils/utils.f90
+++ b/src/3d/utils/utils.f90
@@ -19,7 +19,7 @@ module utils
     use inversion_mod, only : vor2vel, vorticity_tendency
     use parcel_interpl, only : par2grid, grid2par
     use netcdf_reader, only : get_file_type, get_num_steps, get_time, get_netcdf_box
-    use parameters, only : lower, extent, update_parameters, read_zeta_boundary_flag, max_num_parcels
+    use parameters, only : lower, extent, update_parameters, read_zeta_boundary_flag
     use physics, only : read_physical_quantities, print_physical_quantities, l_peref
     implicit none
 
@@ -187,7 +187,8 @@ module utils
 #endif
         end subroutine setup_domain_and_parameters
 
-        subroutine setup_fields
+        ! Reads always the last time step of a field file.
+        subroutine setup_fields_and_parcels
             character(len=16) :: file_type
 
             call field_default
@@ -196,23 +197,18 @@ module utils
                 call setup_restart(trim(restart_file), time%initial, file_type)
 
                 if (file_type == 'fields') then
-                    ! FIXME
-!                     call init_parcels(restart_file, field_tol)
+                    call read_netcdf_field_fields(trim(restart_file), -1)
                 else
                     print *, 'Restart file must be of type "fields".'
                     stop
                 endif
             else
                 time%initial = zero ! make sure user cannot start at arbirtrary time
-                call read_netcdf_field_fields(field_file, 1)
+                call read_netcdf_field_fields(field_file, -1)
             endif
-
-        end subroutine setup_fields
-
-        subroutine setup_parcels
 
             call init_parcels
 
-        end subroutine setup_parcels
+        end subroutine setup_fields_and_parcels
 
 end module utils

--- a/unit-tests/3d/test_parcel_init_3d.f90
+++ b/unit-tests/3d/test_parcel_init_3d.f90
@@ -7,11 +7,12 @@ program test_parcel_init_3d
     use unit_test
     use constants, only : pi, zero, one, two, four, f12, f13, f23, f32
     use parcel_container
-    use parcel_init, only : gen_parcel_scalar_attr, unit_test_parcel_init_alloc, init_timer
+    use parcel_init, only : init_timer, init_parcels
     use parcel_interpl, only : par2grid, par2grid_timer
     use parcel_ellipsoid, only : get_abc
     use fields, only : tbuoyg, field_default
     use parameters, only : update_parameters, dx, ncell, nx, ny, nz, lower, vcell
+    use options, only : parcel
     use timer
     implicit none
 
@@ -19,7 +20,7 @@ program test_parcel_init_3d
     integer :: i, ix, iy, iz, mx, my, mz
     double precision :: rms, rmserr, error
     double precision, allocatable :: workg(:, :, :)
-    double precision :: tol = 1.0d-9
+    double precision :: tol = 6.0d-2
 
      !Number of parcels per grid box = nbgx*nbgz
     integer, parameter :: nbgx = 2, nbgy = nbgx, nbgz = nbgx
@@ -29,9 +30,9 @@ program test_parcel_init_3d
                                    dyf = one / dble(nbgy), &
                                    dzf = one / dble(nbgz)
 
-    nx = 64
-    ny = 64
-    nz = 32
+    nx = 128
+    ny = 128
+    nz = 64
     lower = (/-four, -four, -two/)
     extent = (/8.0d0, 8.0d0, four/)
 
@@ -42,12 +43,10 @@ program test_parcel_init_3d
 
     call field_default
 
-    !Maximum number of parcels:
+    parcel%n_per_cell = 8
 
     !Total number of parcels:
     n_parcels = nbgx * nbgy * nbgz * ncell
-    call parcel_alloc(n_parcels)
-
 
     !--------------------------------------------------------
     ! Define a gridded field "tbuoyg" (this can be arbitrary):
@@ -68,6 +67,10 @@ program test_parcel_init_3d
             enddo
         enddo
     enddo
+
+    !---------------------------
+    ! Generate parcel attribute:
+    call init_parcels
 
     !---------------------------------------------------------
     !Initialise parcel volume positions and volume fractions:
@@ -93,14 +96,6 @@ program test_parcel_init_3d
             enddo
         enddo
     enddo
-
-
-    ! Prepare for "gen_parcel_scalar_attr"
-    call unit_test_parcel_init_alloc
-
-    !---------------------------
-    ! Generate parcel attribute:
-    call gen_parcel_scalar_attr(tbuoyg, tol, parcels%buoyancy)
 
     !
     ! check result
@@ -134,7 +129,7 @@ program test_parcel_init_3d
     ! Maximum error
     error = max(error, maxval(dabs(workg(0:nz, :, :))))
 
-    call print_result_dp('Test parcel initialisation 3D', error, atol=two * tol)
+    call print_result_dp('Test parcel initialisation 3D', error, atol=tol)
 
     call parcel_dealloc
 


### PR DESCRIPTION
We currently use a special algorithm (explained in https://doi.org/10.1016/j.jcpx.2022.100109) to ensure that par2grid yields the initial gridded data. However, this causes over/under shoots of parcel attributes near the boundaries. We now switch to a simpler parcel initialisation that avoids this issue.